### PR TITLE
Redesign CryptoString as a value class (breaking)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,8 +35,8 @@ Package: `com.duck.cryptoroomdb`
 
 Core components:
 - **`CryptoRoomDatabase`** - Abstract base class extending `RoomDatabase`. Manages static `Encryptor`/`Decryptor` instances via `setCryptoHelpers()`. Consumer databases extend this class.
-- **`CryptoString`** - String wrapper implementing `CharSequence`. Holds decrypted values in app code; encryption only happens during DB write via TypeConverter.
-- **`CryptoStringTypeConverter`** - Room TypeConverter that encrypts on write (`CryptoString` -> `String`) and decrypts on read (`String` -> `CryptoString`).
+- **`CryptoString`** - `@JvmInline value class` wrapping a **private** `String` (read via `.value`). Holds decrypted values in app code; encryption only happens during DB write via TypeConverter. The backing property is private on purpose: it stops Room from natively unwrapping the value class to a TEXT column (which would bypass the converter and store plaintext), so the converter is mandatory and its absence is a compile error. Utility operations (`encrypt`, `toCryptoString`, `length`, `isEmpty`, `compareTo`, etc.) are extension functions in `CryptoStringExtensions.kt`.
+- **`CryptoStringTypeConverter`** - Room TypeConverter that encrypts on write (`fromCryptoString`: `CryptoString` -> `String`) and decrypts on read (`toCryptoString`: `String` -> `CryptoString`).
 - **`Encryptor`/`Decryptor`** interfaces - Consumer implements these with their encryption logic. Often a single class implements both.
 
 ### Test App Module (`testapp/`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,10 @@ data class UserEntity(
 
 ## Version Management
 
-- Library version matches Room version (see `libs.versions.toml`)
-- JitPack publishing configured in `CryptoRoomDB/build.gradle.kts`
-- Test app versionName also uses Room version for consistency
+- Library version is `<room>.<roomLibRevision>` — the targeted Room version plus an independent
+  library-release revision (e.g. `2.8.4.1`). Both are in `libs.versions.toml`. Bump
+  `roomLibRevision` for library-only releases; reset it to `1` when `room` is bumped. (A 4th
+  numeric segment is used, not a `-N` suffix, so versions sort *after* the bare Room version.)
+- JitPack publishing configured in `CryptoRoomDB/build.gradle.kts`; a release is a git tag matching
+  the version (e.g. `2.8.4.1`).
+- Test app versionName uses the same `<room>.<roomLibRevision>` string for consistency.

--- a/CryptoRoomDB/build.gradle.kts
+++ b/CryptoRoomDB/build.gradle.kts
@@ -110,7 +110,8 @@ publishing {
             }
             groupId = "com.github.projectdelta6"
             artifactId = project.name
-            version = libs.versions.room.get()
+            // <room>.<roomLibRevision>, e.g. 2.8.4.1 — see gradle/libs.versions.toml.
+            version = "${libs.versions.room.get()}.${libs.versions.roomLibRevision.get()}"
         }
     }
 }

--- a/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/CryptoRoomDataBase.kt
+++ b/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/CryptoRoomDataBase.kt
@@ -31,20 +31,10 @@ abstract class CryptoRoomDatabase : RoomDatabase() {
         private var encryptor: Encryptor? = null
         private var decryptor: Decryptor? = null
 
-        @Throws(EncryptorNotInitializedException::class)
-        fun getEncryptor(): Encryptor {
-            if (encryptor == null) {
-                throw EncryptorNotInitializedException()
-            }
-            return encryptor as Encryptor
-        }
+        internal fun getEncryptor(): Encryptor =
+            encryptor ?: throw EncryptorNotInitializedException()
 
-        @Throws(DecryptorNotInitializedException::class)
-        fun getDecryptor(): Decryptor {
-            if (decryptor == null) {
-                throw DecryptorNotInitializedException()
-            }
-            return decryptor as Decryptor
-        }
+        internal fun getDecryptor(): Decryptor =
+            decryptor ?: throw DecryptorNotInitializedException()
     }
 }

--- a/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/CryptoRoomDataBase.kt
+++ b/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/CryptoRoomDataBase.kt
@@ -11,9 +11,9 @@ import com.duck.cryptoroomdb.typeconverter.CryptoStringTypeConverter
 /**
  * Created by Bradley Duck on 2018/10/19.
  *
- * Wrapper class for [RoomDatabase] with Added DataEncryption through the use of the
- * [CryptoString][com.duck.cryptoroomdb.types.CryptoString] object in your [Entity](s) and
- * including the [CryptoStringTypeConverter] in your [TypeConverters]
+ * Wrapper class for [RoomDatabase] with added field-level encryption through the use of the
+ * [CryptoString][com.duck.cryptoroomdb.types.CryptoString] value class in your [Entity](s) and
+ * including the [CryptoStringTypeConverter] in your [TypeConverters].
  */
 @TypeConverters(value = [CryptoStringTypeConverter::class])
 abstract class CryptoRoomDatabase : RoomDatabase() {

--- a/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/CryptoRoomDataBase.kt
+++ b/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/CryptoRoomDataBase.kt
@@ -1,21 +1,27 @@
 package com.duck.cryptoroomdb
 
 import androidx.room.RoomDatabase
-import androidx.room.TypeConverters
 import com.duck.cryptoroomdb.exceptions.DecryptorNotInitializedException
 import com.duck.cryptoroomdb.exceptions.EncryptorNotInitializedException
 import com.duck.cryptoroomdb.interfaces.Decryptor
 import com.duck.cryptoroomdb.interfaces.Encryptor
-import com.duck.cryptoroomdb.typeconverter.CryptoStringTypeConverter
 
 /**
- * Created by Bradley Duck on 2018/10/19.
+ * Base class for [RoomDatabase]s with field-level encryption.
  *
- * Wrapper class for [RoomDatabase] with added field-level encryption through the use of the
- * [CryptoString][com.duck.cryptoroomdb.types.CryptoString] value class in your [Entity](s) and
- * including the [CryptoStringTypeConverter] in your [TypeConverters].
+ * Store sensitive fields as [CryptoString][com.duck.cryptoroomdb.types.CryptoString] in your
+ * `@Entity`s; they are encrypted on write and decrypted on read by
+ * [CryptoStringTypeConverter][com.duck.cryptoroomdb.typeconverter.CryptoStringTypeConverter].
+ *
+ * To use it:
+ * 1. Extend this class for your `@Database`.
+ * 2. Register the converter on **your** `@Database` with
+ *    `@TypeConverters(CryptoStringTypeConverter::class)`. Room does **not** inherit
+ *    `@TypeConverters` from a superclass, so declaring it here would do nothing — it must be on
+ *    your own `@Database` (and a [CryptoString][com.duck.cryptoroomdb.types.CryptoString] field
+ *    won't compile without it).
+ * 3. Call [setCryptoHelpers] during initialisation, before any database access.
  */
-@TypeConverters(value = [CryptoStringTypeConverter::class])
 abstract class CryptoRoomDatabase : RoomDatabase() {
 
     /**

--- a/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/typeconverter/CryptoStringTypeConverter.kt
+++ b/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/typeconverter/CryptoStringTypeConverter.kt
@@ -3,30 +3,24 @@ package com.duck.cryptoroomdb.typeconverter
 import androidx.room.TypeConverter
 import com.duck.cryptoroomdb.CryptoRoomDatabase
 import com.duck.cryptoroomdb.types.CryptoString
+import com.duck.cryptoroomdb.types.decryptToCryptoString
+import com.duck.cryptoroomdb.types.encrypt
 
 /**
- * Created by Bradley Duck on 2018/10/19.
+ * Room [TypeConverter] for [CryptoString]. This is where the actual encryption happens:
+ * * writing to the DB encrypts the plain value;
+ * * reading from the DB decrypts the stored value.
  *
- * [TypeConverter][androidx.room.TypeConverter] for the [CryptoString] object.<br></br>
- * This is where the actual encryption and decryption happens:<br></br>
- * * The value is encrypted when writing into the DB.<br></br>
- * * The value is decrypted when read out of the DB.
+ * Registering this converter is mandatory — without it Room cannot persist a [CryptoString]
+ * field and the build fails (by design; see [CryptoString]).
  */
 class CryptoStringTypeConverter {
 
     @TypeConverter
-    fun encrypt(_cryptoString: CryptoString?): String {
-        var cryptoString = _cryptoString
-        if (cryptoString == null) {
-            cryptoString = CryptoString()
-        }
-        return cryptoString.encrypt(CryptoRoomDatabase.getEncryptor())
-    }
+    fun fromCryptoString(crypto: CryptoString): String =
+        crypto.encrypt(CryptoRoomDatabase.getEncryptor())
 
     @TypeConverter
-    fun decrypt(encryptedValue: String?): CryptoString {
-        return if (encryptedValue == null) {
-            CryptoString()
-        } else CryptoString(encryptedValue, CryptoRoomDatabase.getDecryptor())
-    }
+    fun toCryptoString(encrypted: String): CryptoString =
+        encrypted.decryptToCryptoString(CryptoRoomDatabase.getDecryptor())
 }

--- a/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/types/CryptoString.kt
+++ b/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/types/CryptoString.kt
@@ -1,99 +1,31 @@
 package com.duck.cryptoroomdb.types
 
-import android.os.Build
-import androidx.annotation.RequiresApi
-import com.duck.cryptoroomdb.interfaces.Decryptor
-import com.duck.cryptoroomdb.interfaces.Encryptor
-import java.util.stream.IntStream
-
 /**
- * Created by Bradley Duck on 2018/10/19.
+ * Type-safe wrapper for strings that should be encrypted when stored in the database.
  *
- * String Wrapper class for the purpose of encrypting the value held within when writing into
- * the DB and decrypting when reading from the DB.
+ * This is a [value class][JvmInline] — compile-time type safety with zero runtime overhead;
+ * at runtime it is just the wrapped `String`.
+ *
+ * **Why the backing property is `private`:** Room natively unwraps a value class that exposes a
+ * persistable underlying type, which would map this straight to a `TEXT` column and **bypass
+ * [CryptoStringTypeConverter][com.duck.cryptoroomdb.typeconverter.CryptoStringTypeConverter],
+ * silently storing plaintext.** Hiding the backing property stops that: Room can no longer
+ * persist the field on its own, so it *requires* the converter and fails to compile without it.
+ * Read the plain value via [value]; construct with `CryptoString("...")`.
+ *
+ * The actual encryption/decryption happens in
+ * [CryptoStringTypeConverter][com.duck.cryptoroomdb.typeconverter.CryptoStringTypeConverter].
  */
-class CryptoString(value: String? = null) : Comparable<CryptoString>, CharSequence {
+@JvmInline
+value class CryptoString(private val raw: String) {
 
-    /**
-     * Copy Constructor.
-     */
-    constructor(value: CryptoString?) : this(value?.value)
-
-    /**
-     * Decryptor Constructor.
-     *
-     * This will decrypt the [encryptedValue] using the [decryptor] and initialise a
-     * new [CryptoString] with the decrypted value
-     *
-     * @param encryptedValue the encrypted [String] to be decrypted.
-     * @param decryptor the [Decryptor] to be used to decrypt the [encryptedValue].
-     */
-    constructor(encryptedValue: String, decryptor: Decryptor) : this(
-        decryptor.decrypt(
-            encryptedValue
-        )
-    )
-
-    /**
-     * internal 'wrapped' [String] value.
-     */
-    var value: String = value ?: ""
-
-    /**
-     * Returns the length of this character sequence.
-     */
-    override val length: Int
-        get() = value.length
-
-    /**
-     * Sets the internal [String] value to match that of the provided [CryptoString].
-     *
-     * @param value [CryptoString] the value to be set.
-     */
-    fun setValue(value: CryptoString) {
-        this.value = value.value
-    }
-
-    /**
-     * Returns a string obtained by concatenating this string with the string representation of the given [other] object.
-     */
-    operator fun plus(other: Any?): String = value.plus(other)
-
-    override operator fun get(index: Int): Char = value[index]
-
-    override fun subSequence(startIndex: Int, endIndex: Int): CharSequence =
-        value.subSequence(startIndex, endIndex)
-
-    override fun equals(other: Any?): Boolean {
-        if (other is CryptoString) {
-            return value == other.value
-        }
-        return if (other is String) {
-            value == other
-        } else super.equals(other)
-    }
-
-    fun equals(other: String?): Boolean {
-        return value == other
-    }
-
-    override operator fun compareTo(other: CryptoString): Int = compareTo(other.value)
-
-    operator fun compareTo(other: String): Int = value.compareTo(other)
-
-    override fun hashCode(): Int = value.hashCode()
-
-    @RequiresApi(Build.VERSION_CODES.N)
-    override fun chars(): IntStream = value.chars()
+    /** The plain (decrypted) value held by this wrapper. */
+    val value: String get() = raw
 
     override fun toString(): String = value
 
-    @RequiresApi(Build.VERSION_CODES.N)
-    override fun codePoints(): IntStream = value.codePoints()
-
-    /**
-     * @param encryptor [Encryptor] to do the actual encryption.
-     * @return The **encrypted** value of this CryptoString.
-     */
-    fun encrypt(encryptor: Encryptor): String = encryptor.encrypt(value)
+    companion object {
+        /** A [CryptoString] wrapping the empty string. */
+        val EMPTY = CryptoString("")
+    }
 }

--- a/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/types/CryptoStringExtensions.kt
+++ b/CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/types/CryptoStringExtensions.kt
@@ -1,0 +1,38 @@
+package com.duck.cryptoroomdb.types
+
+import com.duck.cryptoroomdb.interfaces.Decryptor
+import com.duck.cryptoroomdb.interfaces.Encryptor
+
+/**
+ * Encrypts this [CryptoString]'s value using [encryptor].
+ * @return the encrypted string (ciphertext).
+ */
+fun CryptoString.encrypt(encryptor: Encryptor): String = encryptor.encrypt(value)
+
+/** Wraps this plain [String] in a [CryptoString]. */
+fun String.toCryptoString(): CryptoString = CryptoString(this)
+
+/** Decrypts this encrypted [String] with [decryptor] and wraps the result in a [CryptoString]. */
+fun String.decryptToCryptoString(decryptor: Decryptor): CryptoString =
+    CryptoString(decryptor.decrypt(this))
+
+/** Lexicographically compares the underlying values of two [CryptoString]s. */
+operator fun CryptoString.compareTo(other: CryptoString): Int = value.compareTo(other.value)
+
+/** Returns true if the underlying value equals the plain [other]. */
+fun CryptoString.contentEquals(other: String): Boolean = value == other
+
+/** The length of the underlying value. */
+val CryptoString.length: Int get() = value.length
+
+/** Returns true if the underlying value is empty. */
+fun CryptoString.isEmpty(): Boolean = value.isEmpty()
+
+/** Returns true if the underlying value is not empty. */
+fun CryptoString.isNotEmpty(): Boolean = value.isNotEmpty()
+
+/** Returns true if the underlying value is blank. */
+fun CryptoString.isBlank(): Boolean = value.isBlank()
+
+/** Returns true if the underlying value is not blank. */
+fun CryptoString.isNotBlank(): Boolean = value.isNotBlank()

--- a/CryptoRoomDB/src/test/java/com/duck/cryptoroomdb/CryptoStringExtensionsTest.kt
+++ b/CryptoRoomDB/src/test/java/com/duck/cryptoroomdb/CryptoStringExtensionsTest.kt
@@ -1,0 +1,80 @@
+package com.duck.cryptoroomdb
+
+import com.duck.cryptoroomdb.interfaces.Decryptor
+import com.duck.cryptoroomdb.interfaces.Encryptor
+import com.duck.cryptoroomdb.types.CryptoString
+import com.duck.cryptoroomdb.types.compareTo
+import com.duck.cryptoroomdb.types.contentEquals
+import com.duck.cryptoroomdb.types.decryptToCryptoString
+import com.duck.cryptoroomdb.types.encrypt
+import com.duck.cryptoroomdb.types.isBlank
+import com.duck.cryptoroomdb.types.isEmpty
+import com.duck.cryptoroomdb.types.isNotBlank
+import com.duck.cryptoroomdb.types.isNotEmpty
+import com.duck.cryptoroomdb.types.length
+import com.duck.cryptoroomdb.types.toCryptoString
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/** Pure-JVM unit tests for the [CryptoString] extension functions. */
+class CryptoStringExtensionsTest {
+
+    private val encryptor = object : Encryptor {
+        override fun encrypt(plainValue: String): String = "enc:$plainValue"
+    }
+    private val decryptor = object : Decryptor {
+        override fun decrypt(encryptedValue: String): String = encryptedValue.removePrefix("enc:")
+    }
+
+    @Test
+    fun encrypt_delegatesToEncryptor() {
+        assertEquals("enc:secret", CryptoString("secret").encrypt(encryptor))
+    }
+
+    @Test
+    fun toCryptoString_wrapsString() {
+        assertEquals("x", "x".toCryptoString().value)
+    }
+
+    @Test
+    fun decryptToCryptoString_decryptsAndWraps() {
+        assertEquals("plain", "enc:plain".decryptToCryptoString(decryptor).value)
+    }
+
+    @Test
+    fun compareTo_ordersByUnderlyingValue() {
+        assertEquals(0, CryptoString("a").compareTo(CryptoString("a")))
+        assertTrue(CryptoString("a") < CryptoString("b"))
+        assertTrue(CryptoString("b") > CryptoString("a"))
+    }
+
+    @Test
+    fun contentEquals_comparesUnderlyingValue() {
+        assertTrue(CryptoString("x").contentEquals("x"))
+        assertFalse(CryptoString("x").contentEquals("y"))
+    }
+
+    @Test
+    fun length_returnsUnderlyingLength() {
+        assertEquals(3, CryptoString("abc").length)
+        assertEquals(0, CryptoString.EMPTY.length)
+    }
+
+    @Test
+    fun emptinessChecks() {
+        assertTrue(CryptoString("").isEmpty())
+        assertFalse(CryptoString("a").isEmpty())
+        assertTrue(CryptoString("a").isNotEmpty())
+        assertFalse(CryptoString("").isNotEmpty())
+    }
+
+    @Test
+    fun blanknessChecks() {
+        assertTrue(CryptoString("   ").isBlank())
+        assertFalse(CryptoString("a").isBlank())
+        assertTrue(CryptoString("a").isNotBlank())
+        assertFalse(CryptoString("   ").isNotBlank())
+    }
+}

--- a/CryptoRoomDB/src/test/java/com/duck/cryptoroomdb/CryptoStringTest.kt
+++ b/CryptoRoomDB/src/test/java/com/duck/cryptoroomdb/CryptoStringTest.kt
@@ -1,161 +1,41 @@
 package com.duck.cryptoroomdb
 
-import com.duck.cryptoroomdb.interfaces.Decryptor
-import com.duck.cryptoroomdb.interfaces.Encryptor
 import com.duck.cryptoroomdb.types.CryptoString
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
-import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
- * Pure-JVM unit tests for [CryptoString]. No Android runtime needed — the only `android.*`
- * reference is the `@RequiresApi` annotation constant, which is inlined at compile time.
+ * Pure-JVM unit tests for the [CryptoString] value class. Equality and hashCode are compiler
+ * generated from the wrapped value; this verifies that contract plus [CryptoString.value],
+ * [CryptoString.toString], and the [CryptoString.EMPTY] constant.
  */
 class CryptoStringTest {
 
     @Test
-    fun defaultConstructor_isEmptyString() {
-        val cs = CryptoString()
-        assertEquals("", cs.value)
-        assertEquals(0, cs.length)
-    }
-
-    @Test
-    fun nullStringConstructor_isEmptyString() {
-        assertEquals("", CryptoString(null as String?).value)
-    }
-
-    @Test
-    fun valueConstructor_holdsValue() {
-        val cs = CryptoString("hello")
-        assertEquals("hello", cs.value)
-        assertEquals(5, cs.length)
-    }
-
-    @Test
-    fun copyConstructor_copiesValue() {
-        assertEquals("source", CryptoString(CryptoString("source")).value)
-    }
-
-    @Test
-    fun copyConstructor_withNull_isEmpty() {
-        assertEquals("", CryptoString(null as CryptoString?).value)
-    }
-
-    @Test
-    fun decryptorConstructor_decryptsValue() {
-        val decryptor = object : Decryptor {
-            override fun decrypt(encryptedValue: String): String = encryptedValue.removePrefix("enc:")
-        }
-        assertEquals("plain", CryptoString("enc:plain", decryptor).value)
-    }
-
-    @Test
-    fun setValue_replacesValue() {
-        val cs = CryptoString("old")
-        cs.setValue(CryptoString("new"))
-        assertEquals("new", cs.value)
-    }
-
-    @Test
-    fun mutatingValue_updatesLength() {
-        val cs = CryptoString("a")
-        cs.value = "abcd"
-        assertEquals(4, cs.length)
-    }
-
-    @Test
-    fun plus_concatenatesStringRepresentation() {
-        assertEquals("age:30", CryptoString("age:").plus(30))
-    }
-
-    @Test
-    fun get_returnsCharAtIndex() {
-        assertEquals('b', CryptoString("abc")[1])
-    }
-
-    @Test
-    fun subSequence_returnsSlice() {
-        assertEquals("bcd", CryptoString("abcde").subSequence(1, 4).toString())
-    }
-
-    @Test
-    fun equals_withMatchingCryptoString_isTrue() {
-        assertTrue(CryptoString("x") == CryptoString("x"))
-        assertFalse(CryptoString("x") == CryptoString("y"))
-    }
-
-    @Test
-    fun equals_withMatchingString_isTrue() {
-        // Passing the String as Any? resolves to equals(Any?), hitting its String branch.
-        // (`==` won't compile between the two unrelated final types.)
-        assertTrue(CryptoString("x").equals("x" as Any?))
-        assertFalse(CryptoString("x").equals("y" as Any?))
-    }
-
-    @Test
-    fun equals_withUnrelatedType_isFalse() {
-        assertFalse(CryptoString("1").equals(1))
-        assertFalse(CryptoString("x").equals(null))
-    }
-
-    @Test
-    fun equalsStringOverload_comparesValue() {
-        // Explicit String arg resolves to the equals(String?) overload.
-        assertTrue(CryptoString("x").equals("x"))
-        assertFalse(CryptoString("x").equals("y"))
-        assertFalse(CryptoString("x").equals(null as String?))
-    }
-
-    @Test
-    fun compareTo_cryptoString_ordersByValue() {
-        assertEquals(0, CryptoString("a").compareTo(CryptoString("a")))
-        assertTrue(CryptoString("a") < CryptoString("b"))
-        assertTrue(CryptoString("b") > CryptoString("a"))
-    }
-
-    @Test
-    fun compareTo_string_ordersByValue() {
-        assertEquals(0, CryptoString("a").compareTo("a"))
-        assertTrue(CryptoString("a").compareTo("b") < 0)
-    }
-
-    @Test
-    fun hashCode_matchesUnderlyingString() {
-        assertEquals("hello".hashCode(), CryptoString("hello").hashCode())
-    }
-
-    @Test
-    fun equalInstances_shareHashCode() {
-        assertEquals(CryptoString("k").hashCode(), CryptoString("k").hashCode())
+    fun value_holdsWrappedString() {
+        assertEquals("hello", CryptoString("hello").value)
     }
 
     @Test
     fun toString_returnsValue() {
-        assertEquals("printme", CryptoString("printme").toString())
+        assertEquals("hello", CryptoString("hello").toString())
     }
 
     @Test
-    fun chars_streamsCharacters() {
-        val count = CryptoString("abc").chars().count()
-        assertEquals(3L, count)
+    fun equals_isValueBased() {
+        assertEquals(CryptoString("a"), CryptoString("a"))
+        assertNotEquals(CryptoString("a"), CryptoString("b"))
     }
 
     @Test
-    fun codePoints_streamsCodePoints() {
-        val count = CryptoString("abc").codePoints().count()
-        assertEquals(3L, count)
+    fun hashCode_matchesForEqualValues() {
+        assertEquals(CryptoString("k").hashCode(), CryptoString("k").hashCode())
     }
 
     @Test
-    fun encrypt_delegatesToEncryptor() {
-        val encryptor = object : Encryptor {
-            override fun encrypt(plainValue: String): String = "enc:$plainValue"
-        }
-        val encrypted = CryptoString("secret").encrypt(encryptor)
-        assertEquals("enc:secret", encrypted)
-        assertNotEquals("secret", encrypted)
+    fun empty_wrapsEmptyString() {
+        assertEquals("", CryptoString.EMPTY.value)
+        assertEquals(CryptoString(""), CryptoString.EMPTY)
     }
 }

--- a/CryptoRoomDB/src/test/java/com/duck/cryptoroomdb/CryptoStringTypeConverterTest.kt
+++ b/CryptoRoomDB/src/test/java/com/duck/cryptoroomdb/CryptoStringTypeConverterTest.kt
@@ -12,10 +12,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 /**
- * Exercises every branch of [CryptoStringTypeConverter] in isolation. The converter reaches the
- * crypto helpers through [CryptoRoomDatabase]'s static state, which we populate directly so no
- * database instance is required. Robolectric is used only so loading [CryptoRoomDatabase]
- * (a [androidx.room.RoomDatabase] subclass) is safe on the JVM.
+ * Exercises [CryptoStringTypeConverter]. The converter reaches the crypto helpers through
+ * [CryptoRoomDatabase]'s static state, which we populate directly so no database instance is
+ * required. Robolectric is used only so loading [CryptoRoomDatabase] (a
+ * [androidx.room.RoomDatabase] subclass) is safe on the JVM.
  */
 @RunWith(AndroidJUnit4::class)
 class CryptoStringTypeConverterTest {
@@ -34,23 +34,19 @@ class CryptoStringTypeConverterTest {
     }
 
     @Test
-    fun encrypt_nonNull_usesEncryptor() {
-        assertEquals(cryptor.encrypt("hello"), converter.encrypt(CryptoString("hello")))
+    fun fromCryptoString_encrypts() {
+        assertEquals(cryptor.encrypt("hello"), converter.fromCryptoString(CryptoString("hello")))
     }
 
     @Test
-    fun encrypt_null_encryptsEmptyString() {
-        assertEquals(cryptor.encrypt(""), converter.encrypt(null))
+    fun toCryptoString_decrypts() {
+        assertEquals("world", converter.toCryptoString(cryptor.encrypt("world")).value)
     }
 
     @Test
-    fun decrypt_nonNull_usesDecryptor() {
-        val stored = cryptor.encrypt("world")
-        assertEquals("world", converter.decrypt(stored).value)
-    }
-
-    @Test
-    fun decrypt_null_yieldsEmptyCryptoString() {
-        assertEquals("", converter.decrypt(null).value)
+    fun roundTrip_returnsOriginal() {
+        val original = CryptoString("secret")
+        val restored = converter.toCryptoString(converter.fromCryptoString(original))
+        assertEquals(original, restored)
     }
 }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Add the following to your app/module `build.gradle`:
 
 ```gradle
 dependencies {
-    implementation 'com.github.projectdelta6:CryptoRoomDB:{version}' // Use a version matching your Room version
+    implementation 'com.github.projectdelta6:CryptoRoomDB:{version}' // version is <room>.<revision>, e.g. 2.8.4.1
 }
 ```
 
@@ -107,10 +107,12 @@ itself hold the encrypted value in your app code.**
 > `@TypeConverters(CryptoStringTypeConverter::class)` on your `@Database`, the build fails rather
 > than silently storing plaintext.
 
-> **Migrating from earlier versions:** `CryptoString` is now a value class. The old
-> `CharSequence` behaviour, in-place mutation (`cryptoString.value = …` / `setValue`), the extra
-> constructors (`CryptoString()`, copy, and decryptor constructors), the `+` operator, and
-> `cryptoString == "plainString"` have been removed. Use `.value` (e.g.
+> **⚠️ Migrating to `2.8.4.1` — this is a breaking release.** The version only ticks from `2.8.4`
+> to `2.8.4.1` because it tracks the targeted Room version (the `.1` is the library revision), so
+> the API break is *not* obvious from the number — read this before upgrading. `CryptoString` is now
+> a value class: the old `CharSequence` behaviour, in-place mutation (`cryptoString.value = …` /
+> `setValue`), the extra constructors (`CryptoString()`, copy, and decryptor constructors), the `+`
+> operator, and `cryptoString == "plainString"` have been removed. Use `.value` (e.g.
 > `cryptoString.value == "plainString"`), `String.toCryptoString()`, `copy(secret = CryptoString(…))`
 > on your entity, or the new extension helpers. Entity fields and the `setCryptoHelpers(...)` setup
 > are unchanged.

--- a/README.md
+++ b/README.md
@@ -78,27 +78,42 @@ data class UserEntity(
 
 ## CryptoString Type
 
-The `CryptoString` type is a drop-in String wrapper designed for seamless encryption and decryption
-with Room. **It only ever holds the decrypted (plain) string value in your app code.** The value is
-only encrypted when it is written to the database table, and decrypted automatically when read back.
+The `CryptoString` type is a `@JvmInline value class` wrapping a `String`. **It only ever holds the
+decrypted (plain) value in your app code** — the value is encrypted only when written to the
+database and decrypted automatically when read back. Being a value class, it adds no runtime
+overhead (at runtime it is just the `String`) and is immutable.
 
-You can use `CryptoString` in your entities just like a regular String. It implements `CharSequence`
-and common operators, so it behaves like a String in most app code:
+Access the plain value via `.value`; `toString()` returns it too:
 
 ```kotlin
 val secret = CryptoString("mySecret")
-val plain: String = secret.value // Access the decrypted value
-println(secret) // Prints the decrypted value
+val plain: String = secret.value   // the decrypted value
+println(secret)                    // prints: mySecret
 
-// Use in comparisons and concatenation
-if (secret == "mySecret") { /* ... */
-}
-val combined = secret + "123"
+// Immutable, with value-based equality:
+if (secret == CryptoString("mySecret")) { /* ... */ }   // true
+if (secret.value == "mySecret") { /* ... */ }           // compare against a plain String
 ```
 
+Helper extension functions live alongside it: `String.toCryptoString()`, `contentEquals(String)`,
+`length`, `isEmpty`/`isNotEmpty`/`isBlank`/`isNotBlank`, and `compareTo`.
+
 When used with CryptoRoomDB and the provided TypeConverter, values are automatically encrypted when
-written to the database and decrypted when read. **At no point does the CryptoString instance itself
-hold the encrypted value in your app code.**
+written to the database and decrypted when read. **At no point does the `CryptoString` instance
+itself hold the encrypted value in your app code.**
+
+> **Registering `CryptoStringTypeConverter` is mandatory.** `CryptoString` deliberately hides its
+> backing value, so Room cannot persist the field on its own — if you forget
+> `@TypeConverters(CryptoStringTypeConverter::class)` on your `@Database`, the build fails rather
+> than silently storing plaintext.
+
+> **Migrating from earlier versions:** `CryptoString` is now a value class. The old
+> `CharSequence` behaviour, in-place mutation (`cryptoString.value = …` / `setValue`), the extra
+> constructors (`CryptoString()`, copy, and decryptor constructors), the `+` operator, and
+> `cryptoString == "plainString"` have been removed. Use `.value` (e.g.
+> `cryptoString.value == "plainString"`), `String.toCryptoString()`, `copy(secret = CryptoString(…))`
+> on your entity, or the new extension helpers. Entity fields and the `setCryptoHelpers(...)` setup
+> are unchanged.
 
 ## Usage Example
 

--- a/docs/VALUE_CLASS_REDESIGN.md
+++ b/docs/VALUE_CLASS_REDESIGN.md
@@ -80,9 +80,46 @@ simplicity**. Net: a sound, optional refactor. If/when it's picked up, the work 
 
 1. Land the value class + extension functions + (non-null) converter.
 2. Migrate the unit suite (§0.3) and keep the 95% Kover gate green.
-3. Add a permanent ciphertext round-trip assertion and a README warning to defend against
-   the fail-silent missing-converter regression (§0.1 caveat).
+3. Defend against the fail-silent missing-converter regression — ideally by **not using a
+   value class at all** (§0.7), or failing that a ciphertext round-trip assertion + README
+   warning.
 4. Decide the nullable-vs-empty semantics deliberately (§0.5).
+
+### 0.7 Making "forgot the converter" fail loudly
+
+The fail-silent footgun (§0.1 caveat) is caused specifically by the `@JvmInline value class`
+wrapping `String`: Room auto-unwraps it to a TEXT column, so a missing converter stores
+plaintext with no error. Options, best first:
+
+1. **Don't use a value class — use a plain immutable class.** The redesign's two real goals
+   (simpler API, KMP-readiness) come from dropping the `CharSequence` / `IntStream` /
+   mutable-`value` / multi-constructor cruft — **not** from the `value class` keyword. A plain
+   class delivers both, and Room *cannot* persist it natively, so a missing converter is a
+   **compile error** ("cannot figure out how to save this field") — exactly like today. Cost:
+   one small allocation per field, negligible beside the disk I/O + AES already happening. For
+   a security library, guaranteeing you can't silently store plaintext is worth that. This is
+   the recommended trade.
+   ```kotlin
+   class CryptoString(val value: String) {
+       override fun toString() = value
+       override fun equals(other: Any?) = other is CryptoString && other.value == value
+       override fun hashCode() = value.hashCode()
+       companion object { val EMPTY = CryptoString("") }
+   }
+   ```
+2. **Value class + custom Lint rule** shipped with the library: error when an `@Entity` has a
+   `CryptoString` field whose `@Database` doesn't register `CryptoStringTypeConverter`. Keeps
+   zero-overhead and restores build-time fail-loud — but real implementation effort, and lint
+   is finicky for cross-class Room config.
+3. **Mandatory consumer round-trip test** asserting the raw column is ciphertext — cheap, but
+   runtime, and relies on consumer discipline.
+4. **Value class wrapping a non-Room-persistable underlying type** to force a converter —
+   defeats the "it's just a String" ergonomics; not recommended.
+
+Net: zero-allocation isn't a meaningful requirement for an encrypted DB field, so the
+plain-class option (1) dissolves the footgun for free while keeping most of the redesign's
+value. Reserve the value class for if a profiler ever says these allocations matter — and then
+pair it with the Lint rule (2).
 
 ---
 

--- a/docs/VALUE_CLASS_REDESIGN.md
+++ b/docs/VALUE_CLASS_REDESIGN.md
@@ -1,7 +1,7 @@
 # CryptoRoomDB: Value Class Redesign
 
 **Purpose:** Simplify CryptoString from a wrapper class to a value class while maintaining type safety and Room compatibility.
-**Status:** Proposal — **reviewed & spiked 2026-06-08; technically viable on Room 2.8.4 (see §0)**
+**Status:** **Implemented 2026-06-08** — value class with a private backing property (§0.7); 100% coverage retained, testapp needed no changes.
 **Impact:** Breaking change for direct `CryptoString` construction; TypeConverter *usage* unchanged, but the converter's internals and the library's own test suite need rework.
 
 ---
@@ -635,3 +635,4 @@ class CryptoStringTypeConverterTest {
 | 2026-06-08 | Reviewed against current codebase (tests, Kover gate, CI, AGP 9 / Room 2.8.4). Added §0: critical Room native value-class-unwrap risk (could bypass the converter and store plaintext), TypeConverter name-mangling caveat, test-suite migration scope, and minor staleness fixes. Recommend a round-trip spike before proceeding. |
 | 2026-06-08 | Ran the §0.1/§0.2 spike (throwaway value class + converter + @Database in test sources). Result: Room 2.8.4 invokes the @TypeConverter and stores ciphertext (no plaintext leak); non-null value-class converter signature compiled fine (no mangling issue). Redesign marked technically viable. Exposed a new fail-silent caveat: omitting the converter would store plaintext rather than erroring. |
 | 2026-06-08 | Spiked the fail-silent caveat (§0.7, four variants). Solved: a `private` backing property makes Room decline native unwrapping, so a missing converter is a compile error — while keeping zero-overhead + a String API. Recommended shape is now `value class CryptoString(private val raw: String) { val value get() = raw }`. This removes the last objection to the redesign. |
+| 2026-06-08 | **Implemented.** `CryptoString` is now a value class with a private backing property + `EMPTY`; utilities moved to `CryptoStringExtensions.kt`; converter rewritten non-null (`fromCryptoString`/`toCryptoString`); `getEncryptor`/`getDecryptor` made `internal`. Library unit suite rewritten (value-class basics + extensions + converter); round-trip and not-initialized tests unchanged. 100% coverage retained, 95% gate green; testapp required no changes (uses only `CryptoString("…")` + `.value`). |

--- a/docs/VALUE_CLASS_REDESIGN.md
+++ b/docs/VALUE_CLASS_REDESIGN.md
@@ -1,0 +1,575 @@
+# CryptoRoomDB: Value Class Redesign
+
+**Purpose:** Simplify CryptoString from a wrapper class to a value class while maintaining type safety and Room compatibility.
+**Status:** Proposal — **reviewed 2026-06-08, revisions needed before proceeding (see §0)**
+**Impact:** Breaking change for direct `CryptoString` construction; TypeConverter *usage* unchanged, but the converter's internals and the library's own test suite need rework.
+
+---
+
+## 0. Review Update (2026-06-08)
+
+This plan was written 2026-01-18, before the library gained a test suite, a Kover
+coverage gate, CI, and an AGP 9 / Kotlin 2.4 / Room 2.8.4 upgrade. The core idea
+(value class) still stands, but the context has changed and there is one risk the
+original plan does not address.
+
+### 0.1 🔴 Critical risk to validate FIRST: Room may bypass the TypeConverter
+
+Room **2.6+ natively supports `@JvmInline value class` columns by unwrapping them** to
+the underlying type. Because `CryptoString` would wrap a `String` and the DB column is
+already `String`, Room may map the field **directly to the column and never invoke
+`CryptoStringTypeConverter`** — storing the **plaintext** and silently defeating
+encryption. This is the whole point of the library, so it is a blocker until proven.
+
+Today the wrapper is a plain class, so Room *must* use the converter. As a value class,
+the converter-vs-native-unwrap precedence is unverified and version-dependent.
+
+**De-risk before any redesign work** (cheap now — we have the harness the original plan
+lacked): port `CryptoStringRoundTripTest.storedValue_isEncryptedNotPlainText` to a
+value-class spike. That test reads the raw column and asserts it is ciphertext — it is
+the exact canary for plaintext leakage. If Room unwraps past the converter, the redesign
+is not viable without a different column type (e.g. wrap a distinct type, or store a
+`ByteArray`/tagged type the converter owns).
+
+### 0.2 🟠 TypeConverter name mangling
+
+`@JvmInline value class` parameters produce JVM-mangled method names
+(`fromCryptoString-<hash>`). Room/KSP codegen must resolve these. Nullable params box
+(no mangling), so the plan's nullable signatures may sidestep it — but confirm the
+generated `_Impl` compiles. Part of the same spike as §0.1.
+
+### 0.3 🟠 The test suite must be MIGRATED, not written fresh
+
+§7's example tests predate the real suite. The redesign **deletes API that the current
+`CryptoStringTest` covers**, so these cases must be removed or rewritten as
+extension-function tests: secondary constructors (`CryptoString()`,
+`CryptoString(CryptoString?)`, `CryptoString(encrypted, decryptor)`), `setValue` / mutable
+`value`, `length`-after-mutation, the `equals(String?)` & `equals(Any?)` overloads,
+`compareTo`, `plus`, `get`, `subSequence`, `chars()` / `codePoints()`, and the member
+`encrypt`. The **Kover floor is 95% (suite currently at 100%)** — add tests for every new
+extension function or the gate fails. CI runs `koverVerifyDebug` on PRs into master.
+
+### 0.4 🟢 Consumer impact is smaller than feared
+
+A sweep of the testapp shows it only uses the single-arg `CryptoString("…")` constructor,
+`.value`, and `.copy(...)` — **all of which survive** the redesign. So `UserEntity`,
+`UserViewModel`, and the instrumented `AppDatabaseTest` need no changes. The breakage is
+almost entirely inside the library's own unit tests (§0.3).
+
+### 0.5 🟢 Minor staleness in the sections below
+
+- The "before" `length` (§2.1) was `by this.value::length`; the stale-delegate bug that
+  caused was **fixed 2026-06-08** — it is now `get() = value.length`. The "delegation
+  boilerplate" framing is slightly overstated as a result.
+- §5.1 cites Room KMP "as of 2.7"; the project is now on **Room 2.8.4**.
+- The nullable-vs-empty semantics shift (§3.5 / §2.3) is a *separate* behavior change from
+  the value-class swap: today `decrypt(null)` yields `CryptoString("")`, the plan returns
+  `null`. Decide that deliberately, not as a side effect.
+
+### 0.6 Revised recommendation
+
+Motivation has shifted: the wrapper is now small, 100%-covered, and bug-free, so this is
+no longer pain-driven — the real prize is **KMP-readiness + API simplicity**. Still worth
+doing, but gate it on the §0.1 spike. **Do not start the refactor until the value-class
+round-trip is proven to still encrypt.**
+
+---
+
+## 1. Background
+
+### 1.1 What is a Value Class?
+
+A **value class** (formerly inline class) is a Kotlin feature that wraps a single value with zero runtime overhead. At compile time, it provides type safety; at runtime, it's unwrapped to the underlying type.
+
+```kotlin
+@JvmInline
+value class CryptoString(val value: String)
+
+// At compile time: CryptoString and String are distinct types
+// At runtime: CryptoString is just a String (no object allocation)
+```
+
+**Key benefits:**
+- **Type safety** - Can't accidentally pass a plain `String` where `CryptoString` is expected
+- **Zero overhead** - No object allocation, no wrapper at runtime
+- **KMP compatible** - Works on all Kotlin targets
+
+### 1.2 Current Implementation Issues
+
+The current `CryptoString` wrapper class:
+- Allocates an object for every encrypted field
+- Implements `CharSequence` (rarely needed in practice)
+- Has 99 lines of boilerplate for delegation
+- Uses Android-specific APIs (`@RequiresApi`, `IntStream`)
+
+---
+
+## 2. Proposed Changes
+
+### 2.1 New CryptoString (Value Class)
+
+**Before (99 lines):**
+```kotlin
+class CryptoString(value: String? = null) : Comparable<CryptoString>, CharSequence {
+    constructor(value: CryptoString?) : this(value?.value)
+    constructor(encryptedValue: String, decryptor: Decryptor) : this(decryptor.decrypt(encryptedValue))
+
+    var value: String = value ?: ""
+
+    override val length: Int
+        get() = value.length   // was `by this.value::length` — fixed 2026-06-08 (stale-delegate bug)
+    // ... 80+ more lines of delegation and utilities
+}
+```
+
+**After (15 lines):**
+```kotlin
+/**
+ * Type-safe wrapper for strings that should be encrypted when stored in the database.
+ *
+ * This is a value class (inline class) which provides compile-time type safety
+ * with zero runtime overhead - at runtime, this is just a String.
+ *
+ * The actual encryption/decryption happens in [CryptoStringTypeConverter].
+ */
+@JvmInline
+value class CryptoString(val value: String) {
+    override fun toString(): String = value
+
+    companion object {
+        val EMPTY = CryptoString("")
+    }
+}
+```
+
+### 2.2 Extension Functions (Optional Utilities)
+
+```kotlin
+// CryptoStringExtensions.kt
+
+/**
+ * Encrypts this CryptoString using the provided encryptor.
+ * @return The encrypted string (ciphertext).
+ */
+fun CryptoString.encrypt(encryptor: Encryptor): String =
+    encryptor.encrypt(value)
+
+/**
+ * Converts a plain String to a CryptoString.
+ */
+fun String.toCryptoString(): CryptoString =
+    CryptoString(this)
+
+/**
+ * Decrypts this encrypted String and wraps it in a CryptoString.
+ */
+fun String.decryptToCryptoString(decryptor: Decryptor): CryptoString =
+    CryptoString(decryptor.decrypt(this))
+
+/**
+ * Compares this CryptoString with another.
+ */
+operator fun CryptoString.compareTo(other: CryptoString): Int =
+    value.compareTo(other.value)
+
+/**
+ * Compares this CryptoString with a plain String.
+ */
+fun CryptoString.contentEquals(other: String): Boolean =
+    value == other
+
+/**
+ * Returns the length of the underlying string.
+ */
+val CryptoString.length: Int get() = value.length
+
+/**
+ * Returns true if the underlying string is empty.
+ */
+fun CryptoString.isEmpty(): Boolean = value.isEmpty()
+
+/**
+ * Returns true if the underlying string is not empty.
+ */
+fun CryptoString.isNotEmpty(): Boolean = value.isNotEmpty()
+
+/**
+ * Returns true if the underlying string is blank.
+ */
+fun CryptoString.isBlank(): Boolean = value.isBlank()
+
+/**
+ * Returns true if the underlying string is not blank.
+ */
+fun CryptoString.isNotBlank(): Boolean = value.isNotBlank()
+```
+
+### 2.3 Updated TypeConverter
+
+```kotlin
+/**
+ * Room TypeConverter for [CryptoString].
+ *
+ * - When writing to DB: Encrypts the plain value
+ * - When reading from DB: Decrypts the stored value
+ */
+class CryptoStringTypeConverter {
+
+    @TypeConverter
+    fun fromCryptoString(crypto: CryptoString?): String? {
+        if (crypto == null) return null
+        return crypto.encrypt(CryptoRoomDatabase.getEncryptor())
+    }
+
+    @TypeConverter
+    fun toCryptoString(encrypted: String?): CryptoString? {
+        if (encrypted == null) return null
+        return encrypted.decryptToCryptoString(CryptoRoomDatabase.getDecryptor())
+    }
+}
+```
+
+### 2.4 CryptoRoomDatabase (Simplified)
+
+```kotlin
+/**
+ * Base class for Room databases with field-level encryption support.
+ *
+ * Usage:
+ * 1. Extend this class for your database
+ * 2. Call [setCryptoHelpers] during initialization
+ * 3. Use [CryptoString] for fields that should be encrypted
+ * 4. Include [CryptoStringTypeConverter] in your @TypeConverters
+ */
+@TypeConverters(CryptoStringTypeConverter::class)
+abstract class CryptoRoomDatabase : RoomDatabase() {
+
+    /**
+     * Initialize the encryption/decryption helpers.
+     * Must be called before any database operations.
+     */
+    fun setCryptoHelpers(encryptor: Encryptor, decryptor: Decryptor) {
+        Companion.encryptor = encryptor
+        Companion.decryptor = decryptor
+    }
+
+    companion object {
+        private var encryptor: Encryptor? = null
+        private var decryptor: Decryptor? = null
+
+        internal fun getEncryptor(): Encryptor =
+            encryptor ?: throw EncryptorNotInitializedException()
+
+        internal fun getDecryptor(): Decryptor =
+            decryptor ?: throw DecryptorNotInitializedException()
+    }
+}
+```
+
+---
+
+## 3. Migration Guide
+
+### 3.1 Entity Changes
+
+**No changes required** - entities continue to use `CryptoString`:
+
+```kotlin
+@Entity(tableName = "users")
+data class UserEntity(
+    @PrimaryKey val id: String,
+    val name: String,                    // Not encrypted
+    val email: CryptoString,             // Encrypted
+    val socialSecurityNumber: CryptoString,  // Encrypted
+)
+```
+
+### 3.2 Creating CryptoString Values
+
+**Before:**
+```kotlin
+// Multiple ways to create
+val crypto1 = CryptoString("secret")
+val crypto2 = CryptoString(otherCryptoString)
+val crypto3 = CryptoString(encryptedValue, decryptor)
+```
+
+**After:**
+```kotlin
+// Single constructor
+val crypto1 = CryptoString("secret")
+val crypto2 = "secret".toCryptoString()
+
+// Copy is just assignment (value class is immutable)
+val crypto3 = crypto1
+
+// From encrypted value (rare - usually TypeConverter handles this)
+val crypto4 = encryptedValue.decryptToCryptoString(decryptor)
+```
+
+### 3.3 Accessing the Value
+
+**Before:**
+```kotlin
+val plain: String = cryptoString.value
+val plain2: String = cryptoString.toString()
+val length: Int = cryptoString.length  // CharSequence delegation
+```
+
+**After:**
+```kotlin
+val plain: String = cryptoString.value
+val plain2: String = cryptoString.toString()
+val length: Int = cryptoString.length  // Extension property
+```
+
+### 3.4 Comparisons
+
+**Before:**
+```kotlin
+if (cryptoString == otherCrypto) { }
+if (cryptoString.equals("plaintext")) { }
+```
+
+**After:**
+```kotlin
+if (cryptoString == otherCrypto) { }  // Still works (value equality)
+if (cryptoString.contentEquals("plaintext")) { }  // Extension function
+// Or simply:
+if (cryptoString.value == "plaintext") { }
+```
+
+### 3.5 Nullable Handling
+
+**Before:**
+```kotlin
+val crypto: CryptoString? = null
+val safe = crypto ?: CryptoString()  // Empty default
+```
+
+**After:**
+```kotlin
+val crypto: CryptoString? = null
+val safe = crypto ?: CryptoString.EMPTY  // Companion object constant
+// Or:
+val safe = crypto ?: CryptoString("")
+```
+
+---
+
+## 4. What's Lost (And Why It's OK)
+
+### 4.1 CharSequence Implementation
+
+**Lost:** Can't pass `CryptoString` directly where `CharSequence` is expected.
+
+**Mitigation:** Use `.value` to get the underlying String (which is a CharSequence):
+```kotlin
+textView.text = cryptoString.value  // Instead of cryptoString
+```
+
+**Why it's OK:** In practice, you almost always need the String anyway. The `CharSequence` implementation was rarely used directly.
+
+### 4.2 Mutable `value` Property
+
+**Lost:** Can't modify the value in place:
+```kotlin
+// Before: cryptoString.value = "new value"
+```
+
+**Why it's OK:** Immutability is better. Create a new instance:
+```kotlin
+// After: cryptoString = CryptoString("new value")
+// Or: cryptoString = "new value".toCryptoString()
+```
+
+### 4.3 Copy Constructor
+
+**Lost:** `CryptoString(otherCryptoString)`
+
+**Why it's OK:** Value classes are immutable and inlined. Just assign:
+```kotlin
+val copy = original  // No object to copy - it's just a String at runtime
+```
+
+### 4.4 IntStream Methods (chars(), codePoints())
+
+**Lost:** `@RequiresApi` methods for Java 8 streams.
+
+**Why it's OK:** These were Android-specific and rarely used. Access via `.value` if needed:
+```kotlin
+cryptoString.value.chars()  // If you really need it
+```
+
+---
+
+## 5. KMP Considerations
+
+### 5.1 Room KMP Compatibility
+
+Room supports KMP (since 2.7; the project is currently on **2.8.4**). The value class approach is fully compatible:
+
+```kotlin
+// commonMain - works on all platforms
+@JvmInline
+value class CryptoString(val value: String)
+
+// Room TypeConverter works the same way
+// Encryption implementation can be platform-specific via expect/actual
+```
+
+### 5.2 Platform-Specific Encryption
+
+```kotlin
+// commonMain
+expect fun createEncryptor(key: ByteArray): Encryptor
+expect fun createDecryptor(key: ByteArray): Decryptor
+
+// androidMain - Android Keystore
+actual fun createEncryptor(key: ByteArray): Encryptor =
+    AndroidKeystoreEncryptor(key)
+
+// iosMain - Keychain + CommonCrypto
+actual fun createEncryptor(key: ByteArray): Encryptor =
+    IOSKeychainEncryptor(key)
+
+// jvmMain - BouncyCastle or Java Crypto
+actual fun createEncryptor(key: ByteArray): Encryptor =
+    JvmEncryptor(key)
+```
+
+### 5.3 Future KMP Migration Path
+
+1. **Phase 1 (Now):** Simplify to value class (Android-only)
+2. **Phase 2 (Later):** Move to KMP structure with expect/actual for encryption
+3. **Phase 3 (Later):** Add platform-specific encryption implementations
+
+---
+
+## 6. File Structure (After Redesign)
+
+```
+CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/
+├── CryptoRoomDatabase.kt           # Base database class (simplified)
+├── types/
+│   ├── CryptoString.kt             # Value class (15 lines)
+│   └── CryptoStringExtensions.kt   # Extension functions (optional)
+├── typeconverter/
+│   └── CryptoStringTypeConverter.kt  # Room TypeConverter
+├── interfaces/
+│   ├── Encryptor.kt                # Encryption interface (unchanged)
+│   └── Decryptor.kt                # Decryption interface (unchanged)
+└── exceptions/
+    ├── EncryptorNotInitializedException.kt
+    └── DecryptorNotInitializedException.kt
+```
+
+---
+
+## 7. Testing
+
+> **⚠️ Out of date — see §0.3.** A real test suite now exists (`CryptoStringTest`,
+> `CryptoStringTypeConverterTest`, `CryptoStringRoundTripTest`, `CryptoRoomDatabaseTest`,
+> plus `FakeCryptor`/`TestCryptoDatabase`/`TestEntity`/`TestDao`/`CryptoTestSupport` fixtures).
+> These run on the JVM under Robolectric (`@RunWith(AndroidJUnit4::class)` + `runBlocking`,
+> not `runTest`; `db.testDao` is a property, not `testDao()`). The sketches below must be
+> reconciled with the existing suite and the 95% Kover floor — they are illustrative only.
+
+### 7.1 Value Class Behavior
+
+```kotlin
+class CryptoStringTest {
+
+    @Test
+    fun `value class provides type safety`() {
+        val crypto: CryptoString = CryptoString("secret")
+        val plain: String = "secret"
+
+        // These are different types at compile time
+        // crypto == plain  // Won't compile!
+
+        // Must explicitly compare values
+        assertEquals(crypto.value, plain)
+        assertTrue(crypto.contentEquals(plain))
+    }
+
+    @Test
+    fun `value class has no runtime overhead`() {
+        // At runtime, CryptoString is just a String
+        // No object allocation occurs
+        val crypto = CryptoString("test")
+        assertEquals("test", crypto.value)
+    }
+
+    @Test
+    fun `empty constant works`() {
+        val empty = CryptoString.EMPTY
+        assertTrue(empty.isEmpty())
+        assertEquals("", empty.value)
+    }
+}
+```
+
+### 7.2 TypeConverter Integration
+
+```kotlin
+@RunWith(AndroidJUnit4::class)
+class CryptoStringTypeConverterTest {
+
+    private lateinit var db: TestDatabase
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(context, TestDatabase::class.java)
+            .build()
+        db.setCryptoHelpers(TestEncryptor(), TestDecryptor())
+    }
+
+    @Test
+    fun `encrypted field round-trips correctly`() = runTest {
+        val original = CryptoString("sensitive data")
+        val entity = TestEntity(id = "1", secret = original)
+
+        db.testDao().insert(entity)
+        val retrieved = db.testDao().getById("1")
+
+        assertEquals(original, retrieved.secret)
+        assertEquals("sensitive data", retrieved.secret.value)
+    }
+
+    @Test
+    fun `null encrypted field works`() = runTest {
+        val entity = TestEntity(id = "1", secret = null)
+
+        db.testDao().insert(entity)
+        val retrieved = db.testDao().getById("1")
+
+        assertNull(retrieved.secret)
+    }
+}
+```
+
+---
+
+## 8. Summary
+
+| Aspect | Before (Wrapper) | After (Value Class) |
+|--------|------------------|---------------------|
+| Lines of code | 99 | 15 |
+| Runtime overhead | Object allocation | None |
+| Type safety | Yes | Yes |
+| CharSequence | Yes | No (use `.value`) |
+| Mutable | Yes | No (immutable) |
+| KMP ready | No (IntStream) | Yes |
+| Room compatible | Yes | Yes |
+
+**Recommendation:** Proceed with the value class redesign. The benefits (simplicity, performance, KMP readiness) outweigh the minor inconveniences (accessing `.value` for CharSequence contexts).
+
+---
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-01-18 | Initial design document created |
+| 2026-06-08 | Reviewed against current codebase (tests, Kover gate, CI, AGP 9 / Room 2.8.4). Added §0: critical Room native value-class-unwrap risk (could bypass the converter and store plaintext), TypeConverter name-mangling caveat, test-suite migration scope, and minor staleness fixes. Recommend a round-trip spike before proceeding. |

--- a/docs/VALUE_CLASS_REDESIGN.md
+++ b/docs/VALUE_CLASS_REDESIGN.md
@@ -133,6 +133,27 @@ Options now superseded by the above:
 This removes the only real objection to the redesign: we get value-class simplicity **and**
 zero-overhead **and** the compile-time guarantee that you can't silently persist plaintext.
 
+#### Regression guard — attempted, deferred (2026-06-08)
+
+The invariant ("expose the backing property → Room auto-unwraps → silent plaintext") is
+currently guarded only by the KDoc on [CryptoString] explaining why `raw` is private. A true
+negative-compilation test (assert "CryptoString `@Entity` without the converter fails to
+compile") was attempted via `kotlin-compile-testing` (kctfork) but **deferred**: kctfork 0.7.1
+bundles Kotlin/KSP **2.1.10**, which crashes running Room **2.8.4**'s processor under this
+project's Kotlin 2.4 / KSP 2.3.9 (KSP2 mode NPEs in the KSP engine; KSP1 mode crashes the
+bundled FIR compiler). Revisit when kctfork ships a Kotlin-2.4 / KSP-2.3.x-compatible release.
+The behaviour itself is proven by the §0.7 spike matrix; only the *automated regression guard*
+is outstanding.
+
+#### Incidental finding: the base class `@TypeConverters` is decorative
+
+Spiked separately: a `@Database` extending `CryptoRoomDatabase` does **not** inherit the
+`@TypeConverters(CryptoStringTypeConverter::class)` declared on the base class — Room reads it
+from the annotated `@Database` element, not its supertypes. So consumers must register the
+converter on their own `@Database` (which is what makes the fail-loud guard meaningful), and the
+annotation on `CryptoRoomDatabase` itself does nothing. Candidate for a small follow-up cleanup
+(remove it, or document it as illustrative only).
+
 ---
 
 ## 1. Background

--- a/docs/VALUE_CLASS_REDESIGN.md
+++ b/docs/VALUE_CLASS_REDESIGN.md
@@ -31,10 +31,9 @@ over native unwrapping on **Room 2.8.4 / KSP 2.3.9**. **Not a blocker.**
 > makes Room fall back to native unwrapping and **silently store plaintext** — no error.
 > Today's *class*-based `CryptoString` instead produces a loud compile error if the
 > converter is missing ("cannot figure out how to save this field"). So the redesign trades
-> a fail-loud failure mode for a fail-silent one. Mitigate with a mandatory round-trip test
-> in consumer projects (assert the raw column is ciphertext), and call this out prominently
-> in the README. (Not spike-proven for the *missing*-converter case, but follows directly
-> from the unwrap behaviour — a 5-min confirmation if desired.)
+> a fail-loud failure mode for a fail-silent one. **This is now confirmed by spike and fully
+> mitigated — see §0.7:** giving the value class a `private` backing property makes Room
+> refuse to auto-unwrap, so a missing converter is a compile error again.
 
 ### 0.2 ✅ RESOLVED by spike: no name-mangling problem
 
@@ -80,46 +79,59 @@ simplicity**. Net: a sound, optional refactor. If/when it's picked up, the work 
 
 1. Land the value class + extension functions + (non-null) converter.
 2. Migrate the unit suite (§0.3) and keep the 95% Kover gate green.
-3. Defend against the fail-silent missing-converter regression — ideally by **not using a
-   value class at all** (§0.7), or failing that a ciphertext round-trip assertion + README
-   warning.
+3. Use the **private-backing-property value class** (§0.7) so a forgotten converter is a
+   compile error; keep a ciphertext round-trip test as belt-and-braces.
 4. Decide the nullable-vs-empty semantics deliberately (§0.5).
 
-### 0.7 Making "forgot the converter" fail loudly
+Note `§2.1`'s proposed `value class CryptoString(val value: String)` should become
+`value class CryptoString(private val raw: String) { val value get() = raw }` per §0.7.
 
-The fail-silent footgun (§0.1 caveat) is caused specifically by the `@JvmInline value class`
-wrapping `String`: Room auto-unwraps it to a TEXT column, so a missing converter stores
-plaintext with no error. Options, best first:
+### 0.7 ✅ SOLVED by spike: a private backing property makes it fail loud
 
-1. **Don't use a value class — use a plain immutable class.** The redesign's two real goals
-   (simpler API, KMP-readiness) come from dropping the `CharSequence` / `IntStream` /
-   mutable-`value` / multi-constructor cruft — **not** from the `value class` keyword. A plain
-   class delivers both, and Room *cannot* persist it natively, so a missing converter is a
-   **compile error** ("cannot figure out how to save this field") — exactly like today. Cost:
-   one small allocation per field, negligible beside the disk I/O + AES already happening. For
-   a security library, guaranteeing you can't silently store plaintext is worth that. This is
-   the recommended trade.
-   ```kotlin
-   class CryptoString(val value: String) {
-       override fun toString() = value
-       override fun equals(other: Any?) = other is CryptoString && other.value == value
-       override fun hashCode() = value.hashCode()
-       companion object { val EMPTY = CryptoString("") }
-   }
-   ```
-2. **Value class + custom Lint rule** shipped with the library: error when an `@Entity` has a
-   `CryptoString` field whose `@Database` doesn't register `CryptoStringTypeConverter`. Keeps
-   zero-overhead and restores build-time fail-loud — but real implementation effort, and lint
-   is finicky for cross-class Room config.
-3. **Mandatory consumer round-trip test** asserting the raw column is ciphertext — cheap, but
-   runtime, and relies on consumer discipline.
-4. **Value class wrapping a non-Room-persistable underlying type** to force a converter —
-   defeats the "it's just a String" ergonomics; not recommended.
+The fail-silent footgun (§0.1 caveat) is caused by the `@JvmInline value class` wrapping a
+*publicly visible* `String`: Room auto-unwraps it to a TEXT column, so a missing converter
+stores plaintext with no error.
 
-Net: zero-allocation isn't a meaningful requirement for an encrypted DB field, so the
-plain-class option (1) dissolves the footgun for free while keeping most of the redesign's
-value. Reserve the value class for if a profiler ever says these allocations matter — and then
-pair it with the Lint rule (2).
+**Spike finding (2026-06-08): making the underlying property `private` defeats Room's native
+unwrapping** — KSP then can't persist the field, so a missing `@TypeConverter` is a **compile
+error**, while the class stays a zero-allocation value class with a normal String API. This is
+the recommended shape:
+
+```kotlin
+@JvmInline
+value class CryptoString(private val raw: String) {
+    val value: String get() = raw
+    companion object { val EMPTY = CryptoString("") }
+}
+```
+- `CryptoString("secret")` and `.value` both work (public constructor + public getter).
+- **Zero runtime overhead** — still inlines to `String`; the converter's non-null parameter
+  stays unboxed. Only the *KSP-visible* property is private, which is enough for Room to
+  decline auto-unwrapping.
+- **Fail-loud** — forget `@TypeConverters(CryptoStringTypeConverter::class)` and KSP errors with
+  *"Cannot figure out how to save this property into database"*, exactly like today's class.
+- Proven to round-trip and store **ciphertext** when a converter *is* registered.
+
+Spike matrix (Room 2.8.4 / KSP 2.3.9; no converter unless noted):
+
+| Variant | Backing property | Converter | Result |
+|---|---|---|---|
+| A | `public val` | none | compiles → **fail-silent (plaintext)** ⚠️ |
+| B | `private val` + private ctor | none | compile error → **fail-loud** ✅ |
+| B + converter | `private val` | yes | compiles, round-trips, **stores ciphertext** ✅ |
+| D | `private val` + public ctor | none | compile error → **fail-loud** ✅ |
+
+Constructor visibility is irrelevant — the **private property** is the switch. Variant D is the
+recommended form (cleanest API).
+
+Options now superseded by the above:
+- *Plain (non-value) class* — also fail-loud, but gives up zero-allocation for no gain over the
+  private-property value class.
+- *Custom Lint rule* — unnecessary; the compiler enforces it directly.
+- *Wrapping a non-persistable type* — hacky; the private property achieves the same, cleanly.
+
+This removes the only real objection to the redesign: we get value-class simplicity **and**
+zero-overhead **and** the compile-time guarantee that you can't silently persist plaintext.
 
 ---
 
@@ -622,3 +634,4 @@ class CryptoStringTypeConverterTest {
 | 2026-01-18 | Initial design document created |
 | 2026-06-08 | Reviewed against current codebase (tests, Kover gate, CI, AGP 9 / Room 2.8.4). Added §0: critical Room native value-class-unwrap risk (could bypass the converter and store plaintext), TypeConverter name-mangling caveat, test-suite migration scope, and minor staleness fixes. Recommend a round-trip spike before proceeding. |
 | 2026-06-08 | Ran the §0.1/§0.2 spike (throwaway value class + converter + @Database in test sources). Result: Room 2.8.4 invokes the @TypeConverter and stores ciphertext (no plaintext leak); non-null value-class converter signature compiled fine (no mangling issue). Redesign marked technically viable. Exposed a new fail-silent caveat: omitting the converter would store plaintext rather than erroring. |
+| 2026-06-08 | Spiked the fail-silent caveat (§0.7, four variants). Solved: a `private` backing property makes Room decline native unwrapping, so a missing converter is a compile error — while keeping zero-overhead + a String API. Recommended shape is now `value class CryptoString(private val raw: String) { val value get() = raw }`. This removes the last objection to the redesign. |

--- a/docs/VALUE_CLASS_REDESIGN.md
+++ b/docs/VALUE_CLASS_REDESIGN.md
@@ -1,101 +1,26 @@
-# CryptoRoomDB: Value Class Redesign
+# ADR: `CryptoString` as a value class
 
-**Purpose:** Simplify CryptoString from a wrapper class to a value class while maintaining type safety and Room compatibility.
-**Status:** **Implemented 2026-06-08** — value class with a private backing property (§0.7); 100% coverage retained, testapp needed no changes.
-**Impact:** Breaking change for direct `CryptoString` construction; TypeConverter *usage* unchanged, but the converter's internals and the library's own test suite need rework.
+**Status:** Accepted & implemented (2026-06-08). Original proposal 2026-01-18; reviewed, spiked,
+and implemented since — see [History](#history).
 
----
+> This started as a longer design proposal. Once implemented it was trimmed to this ADR; the
+> original proposal body (with pre-implementation code sketches) remains in git history.
 
-## 0. Review Update (2026-06-08)
+## Context
 
-This plan was written 2026-01-18, before the library gained a test suite, a Kover
-coverage gate, CI, and an AGP 9 / Kotlin 2.4 / Room 2.8.4 upgrade. The core idea
-(value class) still stands, but the context has changed and there is one risk the
-original plan does not address.
+`CryptoString` was a ~99-line class implementing `CharSequence` + `Comparable`, with several
+constructors, a mutable `value`, and Android-only APIs (`IntStream`, `@RequiresApi`). The goals of
+the redesign were a **simpler API** and **KMP-readiness**. By the time it was picked up the library
+also had a full test suite, a 95% Kover gate, and CI.
 
-### 0.1 ✅ RESOLVED by spike: Room uses the converter, does NOT store plaintext
+The central risk: Room 2.6+ **natively unwraps `@JvmInline value class` columns** to their
+underlying type. A `CryptoString` wrapping a `String` could therefore be mapped straight to a `TEXT`
+column and **bypass `CryptoStringTypeConverter`, silently storing plaintext** — the opposite of the
+library's purpose.
 
-The concern: Room **2.6+ natively supports `@JvmInline value class` columns by unwrapping
-them** to the underlying type. Because `CryptoString` would wrap a `String` and the column
-is already `String`, Room *might* map the field directly to the column and never invoke
-`CryptoStringTypeConverter` — storing **plaintext** and silently defeating encryption.
+## Decision
 
-**Spike result (2026-06-08):** Built a throwaway value class + non-null `@TypeConverter`
-(visible reversible transform) + `@Database` in the test sources and asserted on the **raw
-column**. With the converter registered, Room **invoked it and stored ciphertext** — the
-raw value was `ENC:<reversed>`, not the plaintext. So a `@TypeConverter` takes precedence
-over native unwrapping on **Room 2.8.4 / KSP 2.3.9**. **Not a blocker.**
-
-> ⚠️ **New caveat the spike exposes — a safety regression.** That precedence only holds
-> *while the converter is registered*. With a value class, **omitting** `@TypeConverters`
-> makes Room fall back to native unwrapping and **silently store plaintext** — no error.
-> Today's *class*-based `CryptoString` instead produces a loud compile error if the
-> converter is missing ("cannot figure out how to save this field"). So the redesign trades
-> a fail-loud failure mode for a fail-silent one. **This is now confirmed by spike and fully
-> mitigated — see §0.7:** giving the value class a `private` backing property makes Room
-> refuse to auto-unwrap, so a missing converter is a compile error again.
-
-### 0.2 ✅ RESOLVED by spike: no name-mangling problem
-
-The spike's converter used a **non-null** value-class parameter (`fromSpike(SpikeCryptoString)`),
-which is exactly the case that produces a mangled JVM name (`fromSpike-<hash>`). Room/KSP
-codegen resolved it and the generated `_Impl` compiled and ran. **Not an issue** on the
-current toolchain — the plan can use non-null converter signatures if desired.
-
-### 0.3 🟠 The test suite must be MIGRATED, not written fresh
-
-§7's example tests predate the real suite. The redesign **deletes API that the current
-`CryptoStringTest` covers**, so these cases must be removed or rewritten as
-extension-function tests: secondary constructors (`CryptoString()`,
-`CryptoString(CryptoString?)`, `CryptoString(encrypted, decryptor)`), `setValue` / mutable
-`value`, `length`-after-mutation, the `equals(String?)` & `equals(Any?)` overloads,
-`compareTo`, `plus`, `get`, `subSequence`, `chars()` / `codePoints()`, and the member
-`encrypt`. The **Kover floor is 95% (suite currently at 100%)** — add tests for every new
-extension function or the gate fails. CI runs `koverVerifyDebug` on PRs into master.
-
-### 0.4 🟢 Consumer impact is smaller than feared
-
-A sweep of the testapp shows it only uses the single-arg `CryptoString("…")` constructor,
-`.value`, and `.copy(...)` — **all of which survive** the redesign. So `UserEntity`,
-`UserViewModel`, and the instrumented `AppDatabaseTest` need no changes. The breakage is
-almost entirely inside the library's own unit tests (§0.3).
-
-### 0.5 🟢 Minor staleness in the sections below
-
-- The "before" `length` (§2.1) was `by this.value::length`; the stale-delegate bug that
-  caused was **fixed 2026-06-08** — it is now `get() = value.length`. The "delegation
-  boilerplate" framing is slightly overstated as a result.
-- §5.1 cites Room KMP "as of 2.7"; the project is now on **Room 2.8.4**.
-- The nullable-vs-empty semantics shift (§3.5 / §2.3) is a *separate* behavior change from
-  the value-class swap: today `decrypt(null)` yields `CryptoString("")`, the plan returns
-  `null`. Decide that deliberately, not as a side effect.
-
-### 0.6 Revised recommendation
-
-The §0.1 spike clears the only blocker: the value-class redesign **is technically viable**
-on Room 2.8.4. Motivation has shifted, though — the wrapper is now small, 100%-covered, and
-bug-free, so this is no longer pain-driven; the real prize is **KMP-readiness + API
-simplicity**. Net: a sound, optional refactor. If/when it's picked up, the work is:
-
-1. Land the value class + extension functions + (non-null) converter.
-2. Migrate the unit suite (§0.3) and keep the 95% Kover gate green.
-3. Use the **private-backing-property value class** (§0.7) so a forgotten converter is a
-   compile error; keep a ciphertext round-trip test as belt-and-braces.
-4. Decide the nullable-vs-empty semantics deliberately (§0.5).
-
-Note `§2.1`'s proposed `value class CryptoString(val value: String)` should become
-`value class CryptoString(private val raw: String) { val value get() = raw }` per §0.7.
-
-### 0.7 ✅ SOLVED by spike: a private backing property makes it fail loud
-
-The fail-silent footgun (§0.1 caveat) is caused by the `@JvmInline value class` wrapping a
-*publicly visible* `String`: Room auto-unwraps it to a TEXT column, so a missing converter
-stores plaintext with no error.
-
-**Spike finding (2026-06-08): making the underlying property `private` defeats Room's native
-unwrapping** — KSP then can't persist the field, so a missing `@TypeConverter` is a **compile
-error**, while the class stays a zero-allocation value class with a normal String API. This is
-the recommended shape:
+`CryptoString` is a value class with a **private** backing property:
 
 ```kotlin
 @JvmInline
@@ -104,15 +29,18 @@ value class CryptoString(private val raw: String) {
     companion object { val EMPTY = CryptoString("") }
 }
 ```
-- `CryptoString("secret")` and `.value` both work (public constructor + public getter).
-- **Zero runtime overhead** — still inlines to `String`; the converter's non-null parameter
-  stays unboxed. Only the *KSP-visible* property is private, which is enough for Room to
-  decline auto-unwrapping.
-- **Fail-loud** — forget `@TypeConverters(CryptoStringTypeConverter::class)` and KSP errors with
-  *"Cannot figure out how to save this property into database"*, exactly like today's class.
-- Proven to round-trip and store **ciphertext** when a converter *is* registered.
 
-Spike matrix (Room 2.8.4 / KSP 2.3.9; no converter unless noted):
+- Utilities are **extension functions** (`CryptoStringExtensions.kt`): `encrypt`, `toCryptoString`,
+  `decryptToCryptoString`, `compareTo`, `contentEquals`, `length`, `isEmpty`/`isNotEmpty`/
+  `isBlank`/`isNotBlank`.
+- The converter is **non-null**: `fromCryptoString` / `toCryptoString`.
+- `getEncryptor`/`getDecryptor` are `internal`.
+
+## Why the private backing property (the load-bearing choice)
+
+The `private` property is what stops Room's native unwrapping, so the `@TypeConverter` becomes
+**mandatory — forgetting it is a compile error, not a silent plaintext leak**. Proven by spike
+(Room 2.8.4 / KSP 2.3.9; no converter unless noted):
 
 | Variant | Backing property | Converter | Result |
 |---|---|---|---|
@@ -121,539 +49,43 @@ Spike matrix (Room 2.8.4 / KSP 2.3.9; no converter unless noted):
 | B + converter | `private val` | yes | compiles, round-trips, **stores ciphertext** ✅ |
 | D | `private val` + public ctor | none | compile error → **fail-loud** ✅ |
 
-Constructor visibility is irrelevant — the **private property** is the switch. Variant D is the
-recommended form (cleanest API).
-
-Options now superseded by the above:
-- *Plain (non-value) class* — also fail-loud, but gives up zero-allocation for no gain over the
-  private-property value class.
-- *Custom Lint rule* — unnecessary; the compiler enforces it directly.
-- *Wrapping a non-persistable type* — hacky; the private property achieves the same, cleanly.
-
-This removes the only real objection to the redesign: we get value-class simplicity **and**
-zero-overhead **and** the compile-time guarantee that you can't silently persist plaintext.
-
-#### Regression guard — attempted, deferred (2026-06-08)
-
-The invariant ("expose the backing property → Room auto-unwraps → silent plaintext") is
-currently guarded only by the KDoc on [CryptoString] explaining why `raw` is private. A true
-negative-compilation test (assert "CryptoString `@Entity` without the converter fails to
-compile") was attempted via `kotlin-compile-testing` (kctfork) but **deferred**: kctfork 0.7.1
-bundles Kotlin/KSP **2.1.10**, which crashes running Room **2.8.4**'s processor under this
-project's Kotlin 2.4 / KSP 2.3.9 (KSP2 mode NPEs in the KSP engine; KSP1 mode crashes the
-bundled FIR compiler). Revisit when kctfork ships a Kotlin-2.4 / KSP-2.3.x-compatible release.
-The behaviour itself is proven by the §0.7 spike matrix; only the *automated regression guard*
-is outstanding.
-
-#### Incidental finding: the base class `@TypeConverters` is decorative
-
-Spiked separately: a `@Database` extending `CryptoRoomDatabase` does **not** inherit the
-`@TypeConverters(CryptoStringTypeConverter::class)` declared on the base class — Room reads it
-from the annotated `@Database` element, not its supertypes. So consumers must register the
-converter on their own `@Database` (which is what makes the fail-loud guard meaningful), and the
-annotation on `CryptoRoomDatabase` itself does nothing. Candidate for a small follow-up cleanup
-(remove it, or document it as illustrative only).
-
----
-
-## 1. Background
-
-### 1.1 What is a Value Class?
-
-A **value class** (formerly inline class) is a Kotlin feature that wraps a single value with zero runtime overhead. At compile time, it provides type safety; at runtime, it's unwrapped to the underlying type.
-
-```kotlin
-@JvmInline
-value class CryptoString(val value: String)
-
-// At compile time: CryptoString and String are distinct types
-// At runtime: CryptoString is just a String (no object allocation)
-```
-
-**Key benefits:**
-- **Type safety** - Can't accidentally pass a plain `String` where `CryptoString` is expected
-- **Zero overhead** - No object allocation, no wrapper at runtime
-- **KMP compatible** - Works on all Kotlin targets
-
-### 1.2 Current Implementation Issues
-
-The current `CryptoString` wrapper class:
-- Allocates an object for every encrypted field
-- Implements `CharSequence` (rarely needed in practice)
-- Has 99 lines of boilerplate for delegation
-- Uses Android-specific APIs (`@RequiresApi`, `IntStream`)
-
----
-
-## 2. Proposed Changes
-
-### 2.1 New CryptoString (Value Class)
-
-**Before (99 lines):**
-```kotlin
-class CryptoString(value: String? = null) : Comparable<CryptoString>, CharSequence {
-    constructor(value: CryptoString?) : this(value?.value)
-    constructor(encryptedValue: String, decryptor: Decryptor) : this(decryptor.decrypt(encryptedValue))
-
-    var value: String = value ?: ""
-
-    override val length: Int
-        get() = value.length   // was `by this.value::length` — fixed 2026-06-08 (stale-delegate bug)
-    // ... 80+ more lines of delegation and utilities
-}
-```
-
-**After (15 lines):**
-```kotlin
-/**
- * Type-safe wrapper for strings that should be encrypted when stored in the database.
- *
- * This is a value class (inline class) which provides compile-time type safety
- * with zero runtime overhead - at runtime, this is just a String.
- *
- * The actual encryption/decryption happens in [CryptoStringTypeConverter].
- */
-@JvmInline
-value class CryptoString(val value: String) {
-    override fun toString(): String = value
-
-    companion object {
-        val EMPTY = CryptoString("")
-    }
-}
-```
-
-### 2.2 Extension Functions (Optional Utilities)
-
-```kotlin
-// CryptoStringExtensions.kt
-
-/**
- * Encrypts this CryptoString using the provided encryptor.
- * @return The encrypted string (ciphertext).
- */
-fun CryptoString.encrypt(encryptor: Encryptor): String =
-    encryptor.encrypt(value)
-
-/**
- * Converts a plain String to a CryptoString.
- */
-fun String.toCryptoString(): CryptoString =
-    CryptoString(this)
-
-/**
- * Decrypts this encrypted String and wraps it in a CryptoString.
- */
-fun String.decryptToCryptoString(decryptor: Decryptor): CryptoString =
-    CryptoString(decryptor.decrypt(this))
-
-/**
- * Compares this CryptoString with another.
- */
-operator fun CryptoString.compareTo(other: CryptoString): Int =
-    value.compareTo(other.value)
-
-/**
- * Compares this CryptoString with a plain String.
- */
-fun CryptoString.contentEquals(other: String): Boolean =
-    value == other
-
-/**
- * Returns the length of the underlying string.
- */
-val CryptoString.length: Int get() = value.length
-
-/**
- * Returns true if the underlying string is empty.
- */
-fun CryptoString.isEmpty(): Boolean = value.isEmpty()
-
-/**
- * Returns true if the underlying string is not empty.
- */
-fun CryptoString.isNotEmpty(): Boolean = value.isNotEmpty()
-
-/**
- * Returns true if the underlying string is blank.
- */
-fun CryptoString.isBlank(): Boolean = value.isBlank()
-
-/**
- * Returns true if the underlying string is not blank.
- */
-fun CryptoString.isNotBlank(): Boolean = value.isNotBlank()
-```
-
-### 2.3 Updated TypeConverter
-
-```kotlin
-/**
- * Room TypeConverter for [CryptoString].
- *
- * - When writing to DB: Encrypts the plain value
- * - When reading from DB: Decrypts the stored value
- */
-class CryptoStringTypeConverter {
-
-    @TypeConverter
-    fun fromCryptoString(crypto: CryptoString?): String? {
-        if (crypto == null) return null
-        return crypto.encrypt(CryptoRoomDatabase.getEncryptor())
-    }
-
-    @TypeConverter
-    fun toCryptoString(encrypted: String?): CryptoString? {
-        if (encrypted == null) return null
-        return encrypted.decryptToCryptoString(CryptoRoomDatabase.getDecryptor())
-    }
-}
-```
-
-### 2.4 CryptoRoomDatabase (Simplified)
-
-```kotlin
-/**
- * Base class for Room databases with field-level encryption support.
- *
- * Usage:
- * 1. Extend this class for your database
- * 2. Call [setCryptoHelpers] during initialization
- * 3. Use [CryptoString] for fields that should be encrypted
- * 4. Include [CryptoStringTypeConverter] in your @TypeConverters
- */
-@TypeConverters(CryptoStringTypeConverter::class)
-abstract class CryptoRoomDatabase : RoomDatabase() {
-
-    /**
-     * Initialize the encryption/decryption helpers.
-     * Must be called before any database operations.
-     */
-    fun setCryptoHelpers(encryptor: Encryptor, decryptor: Decryptor) {
-        Companion.encryptor = encryptor
-        Companion.decryptor = decryptor
-    }
-
-    companion object {
-        private var encryptor: Encryptor? = null
-        private var decryptor: Decryptor? = null
-
-        internal fun getEncryptor(): Encryptor =
-            encryptor ?: throw EncryptorNotInitializedException()
-
-        internal fun getDecryptor(): Decryptor =
-            decryptor ?: throw DecryptorNotInitializedException()
-    }
-}
-```
-
----
-
-## 3. Migration Guide
-
-### 3.1 Entity Changes
-
-**No changes required** - entities continue to use `CryptoString`:
-
-```kotlin
-@Entity(tableName = "users")
-data class UserEntity(
-    @PrimaryKey val id: String,
-    val name: String,                    // Not encrypted
-    val email: CryptoString,             // Encrypted
-    val socialSecurityNumber: CryptoString,  // Encrypted
-)
-```
-
-### 3.2 Creating CryptoString Values
-
-**Before:**
-```kotlin
-// Multiple ways to create
-val crypto1 = CryptoString("secret")
-val crypto2 = CryptoString(otherCryptoString)
-val crypto3 = CryptoString(encryptedValue, decryptor)
-```
-
-**After:**
-```kotlin
-// Single constructor
-val crypto1 = CryptoString("secret")
-val crypto2 = "secret".toCryptoString()
-
-// Copy is just assignment (value class is immutable)
-val crypto3 = crypto1
-
-// From encrypted value (rare - usually TypeConverter handles this)
-val crypto4 = encryptedValue.decryptToCryptoString(decryptor)
-```
-
-### 3.3 Accessing the Value
-
-**Before:**
-```kotlin
-val plain: String = cryptoString.value
-val plain2: String = cryptoString.toString()
-val length: Int = cryptoString.length  // CharSequence delegation
-```
-
-**After:**
-```kotlin
-val plain: String = cryptoString.value
-val plain2: String = cryptoString.toString()
-val length: Int = cryptoString.length  // Extension property
-```
-
-### 3.4 Comparisons
-
-**Before:**
-```kotlin
-if (cryptoString == otherCrypto) { }
-if (cryptoString.equals("plaintext")) { }
-```
-
-**After:**
-```kotlin
-if (cryptoString == otherCrypto) { }  // Still works (value equality)
-if (cryptoString.contentEquals("plaintext")) { }  // Extension function
-// Or simply:
-if (cryptoString.value == "plaintext") { }
-```
-
-### 3.5 Nullable Handling
-
-**Before:**
-```kotlin
-val crypto: CryptoString? = null
-val safe = crypto ?: CryptoString()  // Empty default
-```
-
-**After:**
-```kotlin
-val crypto: CryptoString? = null
-val safe = crypto ?: CryptoString.EMPTY  // Companion object constant
-// Or:
-val safe = crypto ?: CryptoString("")
-```
-
----
-
-## 4. What's Lost (And Why It's OK)
-
-### 4.1 CharSequence Implementation
-
-**Lost:** Can't pass `CryptoString` directly where `CharSequence` is expected.
-
-**Mitigation:** Use `.value` to get the underlying String (which is a CharSequence):
-```kotlin
-textView.text = cryptoString.value  // Instead of cryptoString
-```
-
-**Why it's OK:** In practice, you almost always need the String anyway. The `CharSequence` implementation was rarely used directly.
-
-### 4.2 Mutable `value` Property
-
-**Lost:** Can't modify the value in place:
-```kotlin
-// Before: cryptoString.value = "new value"
-```
-
-**Why it's OK:** Immutability is better. Create a new instance:
-```kotlin
-// After: cryptoString = CryptoString("new value")
-// Or: cryptoString = "new value".toCryptoString()
-```
-
-### 4.3 Copy Constructor
-
-**Lost:** `CryptoString(otherCryptoString)`
-
-**Why it's OK:** Value classes are immutable and inlined. Just assign:
-```kotlin
-val copy = original  // No object to copy - it's just a String at runtime
-```
-
-### 4.4 IntStream Methods (chars(), codePoints())
-
-**Lost:** `@RequiresApi` methods for Java 8 streams.
-
-**Why it's OK:** These were Android-specific and rarely used. Access via `.value` if needed:
-```kotlin
-cryptoString.value.chars()  // If you really need it
-```
-
----
-
-## 5. KMP Considerations
-
-### 5.1 Room KMP Compatibility
-
-Room supports KMP (since 2.7; the project is currently on **2.8.4**). The value class approach is fully compatible:
-
-```kotlin
-// commonMain - works on all platforms
-@JvmInline
-value class CryptoString(val value: String)
-
-// Room TypeConverter works the same way
-// Encryption implementation can be platform-specific via expect/actual
-```
-
-### 5.2 Platform-Specific Encryption
-
-```kotlin
-// commonMain
-expect fun createEncryptor(key: ByteArray): Encryptor
-expect fun createDecryptor(key: ByteArray): Decryptor
-
-// androidMain - Android Keystore
-actual fun createEncryptor(key: ByteArray): Encryptor =
-    AndroidKeystoreEncryptor(key)
-
-// iosMain - Keychain + CommonCrypto
-actual fun createEncryptor(key: ByteArray): Encryptor =
-    IOSKeychainEncryptor(key)
-
-// jvmMain - BouncyCastle or Java Crypto
-actual fun createEncryptor(key: ByteArray): Encryptor =
-    JvmEncryptor(key)
-```
-
-### 5.3 Future KMP Migration Path
-
-1. **Phase 1 (Now):** Simplify to value class (Android-only)
-2. **Phase 2 (Later):** Move to KMP structure with expect/actual for encryption
-3. **Phase 3 (Later):** Add platform-specific encryption implementations
-
----
-
-## 6. File Structure (After Redesign)
-
-```
-CryptoRoomDB/src/main/java/com/duck/cryptoroomdb/
-├── CryptoRoomDatabase.kt           # Base database class (simplified)
-├── types/
-│   ├── CryptoString.kt             # Value class (15 lines)
-│   └── CryptoStringExtensions.kt   # Extension functions (optional)
-├── typeconverter/
-│   └── CryptoStringTypeConverter.kt  # Room TypeConverter
-├── interfaces/
-│   ├── Encryptor.kt                # Encryption interface (unchanged)
-│   └── Decryptor.kt                # Decryption interface (unchanged)
-└── exceptions/
-    ├── EncryptorNotInitializedException.kt
-    └── DecryptorNotInitializedException.kt
-```
-
----
-
-## 7. Testing
-
-> **⚠️ Out of date — see §0.3.** A real test suite now exists (`CryptoStringTest`,
-> `CryptoStringTypeConverterTest`, `CryptoStringRoundTripTest`, `CryptoRoomDatabaseTest`,
-> plus `FakeCryptor`/`TestCryptoDatabase`/`TestEntity`/`TestDao`/`CryptoTestSupport` fixtures).
-> These run on the JVM under Robolectric (`@RunWith(AndroidJUnit4::class)` + `runBlocking`,
-> not `runTest`; `db.testDao` is a property, not `testDao()`). The sketches below must be
-> reconciled with the existing suite and the 95% Kover floor — they are illustrative only.
-
-### 7.1 Value Class Behavior
-
-```kotlin
-class CryptoStringTest {
-
-    @Test
-    fun `value class provides type safety`() {
-        val crypto: CryptoString = CryptoString("secret")
-        val plain: String = "secret"
-
-        // These are different types at compile time
-        // crypto == plain  // Won't compile!
-
-        // Must explicitly compare values
-        assertEquals(crypto.value, plain)
-        assertTrue(crypto.contentEquals(plain))
-    }
-
-    @Test
-    fun `value class has no runtime overhead`() {
-        // At runtime, CryptoString is just a String
-        // No object allocation occurs
-        val crypto = CryptoString("test")
-        assertEquals("test", crypto.value)
-    }
-
-    @Test
-    fun `empty constant works`() {
-        val empty = CryptoString.EMPTY
-        assertTrue(empty.isEmpty())
-        assertEquals("", empty.value)
-    }
-}
-```
-
-### 7.2 TypeConverter Integration
-
-```kotlin
-@RunWith(AndroidJUnit4::class)
-class CryptoStringTypeConverterTest {
-
-    private lateinit var db: TestDatabase
-
-    @Before
-    fun setup() {
-        db = Room.inMemoryDatabaseBuilder(context, TestDatabase::class.java)
-            .build()
-        db.setCryptoHelpers(TestEncryptor(), TestDecryptor())
-    }
-
-    @Test
-    fun `encrypted field round-trips correctly`() = runTest {
-        val original = CryptoString("sensitive data")
-        val entity = TestEntity(id = "1", secret = original)
-
-        db.testDao().insert(entity)
-        val retrieved = db.testDao().getById("1")
-
-        assertEquals(original, retrieved.secret)
-        assertEquals("sensitive data", retrieved.secret.value)
-    }
-
-    @Test
-    fun `null encrypted field works`() = runTest {
-        val entity = TestEntity(id = "1", secret = null)
-
-        db.testDao().insert(entity)
-        val retrieved = db.testDao().getById("1")
-
-        assertNull(retrieved.secret)
-    }
-}
-```
-
----
-
-## 8. Summary
-
-| Aspect | Before (Wrapper) | After (Value Class) |
-|--------|------------------|---------------------|
-| Lines of code | 99 | 15 |
-| Runtime overhead | Object allocation | None |
-| Type safety | Yes | Yes |
-| CharSequence | Yes | No (use `.value`) |
-| Mutable | Yes | No (immutable) |
-| KMP ready | No (IntStream) | Yes |
-| Room compatible | Yes | Yes |
-
-**Recommendation:** Proceed with the value class redesign. The benefits (simplicity, performance, KMP readiness) outweigh the minor inconveniences (accessing `.value` for CharSequence contexts).
-
----
-
-## Changelog
-
-| Date | Change |
-|------|--------|
-| 2026-01-18 | Initial design document created |
-| 2026-06-08 | Reviewed against current codebase (tests, Kover gate, CI, AGP 9 / Room 2.8.4). Added §0: critical Room native value-class-unwrap risk (could bypass the converter and store plaintext), TypeConverter name-mangling caveat, test-suite migration scope, and minor staleness fixes. Recommend a round-trip spike before proceeding. |
-| 2026-06-08 | Ran the §0.1/§0.2 spike (throwaway value class + converter + @Database in test sources). Result: Room 2.8.4 invokes the @TypeConverter and stores ciphertext (no plaintext leak); non-null value-class converter signature compiled fine (no mangling issue). Redesign marked technically viable. Exposed a new fail-silent caveat: omitting the converter would store plaintext rather than erroring. |
-| 2026-06-08 | Spiked the fail-silent caveat (§0.7, four variants). Solved: a `private` backing property makes Room decline native unwrapping, so a missing converter is a compile error — while keeping zero-overhead + a String API. Recommended shape is now `value class CryptoString(private val raw: String) { val value get() = raw }`. This removes the last objection to the redesign. |
-| 2026-06-08 | **Implemented.** `CryptoString` is now a value class with a private backing property + `EMPTY`; utilities moved to `CryptoStringExtensions.kt`; converter rewritten non-null (`fromCryptoString`/`toCryptoString`); `getEncryptor`/`getDecryptor` made `internal`. Library unit suite rewritten (value-class basics + extensions + converter); round-trip and not-initialized tests unchanged. 100% coverage retained, 95% gate green; testapp required no changes (uses only `CryptoString("…")` + `.value`). |
+Constructor visibility is irrelevant — the private property is the switch (so the public
+constructor + `CryptoString("x")` ergonomics are kept). Zero overhead is retained (it still inlines
+to `String`; the non-null converter parameter stays unboxed). The non-null converter signature
+compiled cleanly — **no value-class name-mangling problem** on this toolchain. A plain class or a
+custom Lint rule were considered and rejected: the private-property value class gives fail-loud
+*and* zero-overhead with no extra machinery.
+
+## Consequences
+
+- **Breaking API change.** Removed: `CharSequence`, `Comparable`, the secondary constructors
+  (no-arg, copy, decryptor), mutable `value`/`setValue`, `plus`, `get`, `subSequence`,
+  `chars`/`codePoints`, and the member `encrypt`. Most live on as extensions; read via `.value`.
+  `CryptoString` is now immutable — "update" by replacing it (`entity.copy(secret = CryptoString(…))`).
+- **Consumer impact is small.** The testapp used only `CryptoString("…")`, `.value`, and `.copy(...)`
+  — all of which survive — so it needed no changes. Breakage was confined to the library's own unit
+  tests, which were migrated. **100% coverage retained**, 95% gate green.
+- **Semantics:** chose non-null `CryptoString` + non-null converter (matches real usage and the
+  proven spike). Nullable encrypted fields would need their own nullable converter (untested) — out
+  of scope for now.
+- **Base-class `@TypeConverters` removed.** Room does not inherit `@TypeConverters` from a
+  `@Database`'s superclass (verified by spike), so the annotation on `CryptoRoomDatabase` was dead
+  and misleading. Consumers register the converter on their own `@Database` — which a `CryptoString`
+  field won't compile without anyway.
+
+## Outstanding
+
+- **Automated regression guard deferred.** The fail-loud invariant (private backing property) is not
+  yet guarded by a test. A true negative-compilation test via `kotlin-compile-testing` (kctfork
+  0.7.1) is blocked: kctfork bundles Kotlin/KSP **2.1.10**, which crashes running Room 2.8.4's
+  processor under Kotlin 2.4 / KSP 2.3.9 (KSP2 NPEs in the engine; KSP1 crashes the bundled FIR
+  compiler). Revisit when kctfork ships a Kotlin-2.4 / KSP-2.3.x-compatible release. Until then the
+  invariant rests on the KDoc on `CryptoString` and the spike evidence above.
+
+## History
+
+| Date | Event |
+|------|-------|
+| 2026-01-18 | Original proposal authored (full design preserved in git history). |
+| 2026-06-08 | Reviewed against the current codebase. Spiked Room's value-class behaviour: a registered `@TypeConverter` is used and stores ciphertext (no plaintext leak); a non-null value-class converter signature compiles (no mangling issue); a **private** backing property makes a missing converter a compile error; Room does not inherit `@TypeConverters` from a superclass. |
+| 2026-06-08 | Implemented: value class + extensions + non-null converter + `internal` getters; unit suite migrated (100% coverage); decorative base-class `@TypeConverters` removed; README/KDoc updated. Negative-compilation guard deferred (kctfork/Kotlin-2.4 incompatibility). |

--- a/docs/VALUE_CLASS_REDESIGN.md
+++ b/docs/VALUE_CLASS_REDESIGN.md
@@ -1,7 +1,7 @@
 # CryptoRoomDB: Value Class Redesign
 
 **Purpose:** Simplify CryptoString from a wrapper class to a value class while maintaining type safety and Room compatibility.
-**Status:** Proposal — **reviewed 2026-06-08, revisions needed before proceeding (see §0)**
+**Status:** Proposal — **reviewed & spiked 2026-06-08; technically viable on Room 2.8.4 (see §0)**
 **Impact:** Breaking change for direct `CryptoString` construction; TypeConverter *usage* unchanged, but the converter's internals and the library's own test suite need rework.
 
 ---
@@ -13,30 +13,35 @@ coverage gate, CI, and an AGP 9 / Kotlin 2.4 / Room 2.8.4 upgrade. The core idea
 (value class) still stands, but the context has changed and there is one risk the
 original plan does not address.
 
-### 0.1 🔴 Critical risk to validate FIRST: Room may bypass the TypeConverter
+### 0.1 ✅ RESOLVED by spike: Room uses the converter, does NOT store plaintext
 
-Room **2.6+ natively supports `@JvmInline value class` columns by unwrapping them** to
-the underlying type. Because `CryptoString` would wrap a `String` and the DB column is
-already `String`, Room may map the field **directly to the column and never invoke
-`CryptoStringTypeConverter`** — storing the **plaintext** and silently defeating
-encryption. This is the whole point of the library, so it is a blocker until proven.
+The concern: Room **2.6+ natively supports `@JvmInline value class` columns by unwrapping
+them** to the underlying type. Because `CryptoString` would wrap a `String` and the column
+is already `String`, Room *might* map the field directly to the column and never invoke
+`CryptoStringTypeConverter` — storing **plaintext** and silently defeating encryption.
 
-Today the wrapper is a plain class, so Room *must* use the converter. As a value class,
-the converter-vs-native-unwrap precedence is unverified and version-dependent.
+**Spike result (2026-06-08):** Built a throwaway value class + non-null `@TypeConverter`
+(visible reversible transform) + `@Database` in the test sources and asserted on the **raw
+column**. With the converter registered, Room **invoked it and stored ciphertext** — the
+raw value was `ENC:<reversed>`, not the plaintext. So a `@TypeConverter` takes precedence
+over native unwrapping on **Room 2.8.4 / KSP 2.3.9**. **Not a blocker.**
 
-**De-risk before any redesign work** (cheap now — we have the harness the original plan
-lacked): port `CryptoStringRoundTripTest.storedValue_isEncryptedNotPlainText` to a
-value-class spike. That test reads the raw column and asserts it is ciphertext — it is
-the exact canary for plaintext leakage. If Room unwraps past the converter, the redesign
-is not viable without a different column type (e.g. wrap a distinct type, or store a
-`ByteArray`/tagged type the converter owns).
+> ⚠️ **New caveat the spike exposes — a safety regression.** That precedence only holds
+> *while the converter is registered*. With a value class, **omitting** `@TypeConverters`
+> makes Room fall back to native unwrapping and **silently store plaintext** — no error.
+> Today's *class*-based `CryptoString` instead produces a loud compile error if the
+> converter is missing ("cannot figure out how to save this field"). So the redesign trades
+> a fail-loud failure mode for a fail-silent one. Mitigate with a mandatory round-trip test
+> in consumer projects (assert the raw column is ciphertext), and call this out prominently
+> in the README. (Not spike-proven for the *missing*-converter case, but follows directly
+> from the unwrap behaviour — a 5-min confirmation if desired.)
 
-### 0.2 🟠 TypeConverter name mangling
+### 0.2 ✅ RESOLVED by spike: no name-mangling problem
 
-`@JvmInline value class` parameters produce JVM-mangled method names
-(`fromCryptoString-<hash>`). Room/KSP codegen must resolve these. Nullable params box
-(no mangling), so the plan's nullable signatures may sidestep it — but confirm the
-generated `_Impl` compiles. Part of the same spike as §0.1.
+The spike's converter used a **non-null** value-class parameter (`fromSpike(SpikeCryptoString)`),
+which is exactly the case that produces a mangled JVM name (`fromSpike-<hash>`). Room/KSP
+codegen resolved it and the generated `_Impl` compiled and ran. **Not an issue** on the
+current toolchain — the plan can use non-null converter signatures if desired.
 
 ### 0.3 🟠 The test suite must be MIGRATED, not written fresh
 
@@ -68,10 +73,16 @@ almost entirely inside the library's own unit tests (§0.3).
 
 ### 0.6 Revised recommendation
 
-Motivation has shifted: the wrapper is now small, 100%-covered, and bug-free, so this is
-no longer pain-driven — the real prize is **KMP-readiness + API simplicity**. Still worth
-doing, but gate it on the §0.1 spike. **Do not start the refactor until the value-class
-round-trip is proven to still encrypt.**
+The §0.1 spike clears the only blocker: the value-class redesign **is technically viable**
+on Room 2.8.4. Motivation has shifted, though — the wrapper is now small, 100%-covered, and
+bug-free, so this is no longer pain-driven; the real prize is **KMP-readiness + API
+simplicity**. Net: a sound, optional refactor. If/when it's picked up, the work is:
+
+1. Land the value class + extension functions + (non-null) converter.
+2. Migrate the unit suite (§0.3) and keep the 95% Kover gate green.
+3. Add a permanent ciphertext round-trip assertion and a README warning to defend against
+   the fail-silent missing-converter regression (§0.1 caveat).
+4. Decide the nullable-vs-empty semantics deliberately (§0.5).
 
 ---
 
@@ -573,3 +584,4 @@ class CryptoStringTypeConverterTest {
 |------|--------|
 | 2026-01-18 | Initial design document created |
 | 2026-06-08 | Reviewed against current codebase (tests, Kover gate, CI, AGP 9 / Room 2.8.4). Added §0: critical Room native value-class-unwrap risk (could bypass the converter and store plaintext), TypeConverter name-mangling caveat, test-suite migration scope, and minor staleness fixes. Recommend a round-trip spike before proceeding. |
+| 2026-06-08 | Ran the §0.1/§0.2 spike (throwaway value class + converter + @Database in test sources). Result: Room 2.8.4 invokes the @TypeConverter and stores ciphertext (no plaintext leak); non-null value-class converter signature compiled fine (no mangling issue). Redesign marked technically viable. Exposed a new fail-silent caveat: omitting the converter would store plaintext rather than erroring. |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,9 @@ ksp = "2.3.9"
 
 # Libraries
 room = "2.8.4"
+# Independent library-release revision appended to the Room version (e.g. 2.8.4.1).
+# Bump for library-only releases; reset to 1 when `room` is bumped.
+roomLibRevision = "1"
 compose-bom = "2026.05.01"
 core-ktx = "1.19.0"
 lifecycle-runtime-ktx = "2.10.0"

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -18,7 +18,7 @@ configure<ApplicationExtension> {
         minSdk = 27
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 1
-        versionName = libs.versions.room.get()
+        versionName = "${libs.versions.room.get()}.${libs.versions.roomLibRevision.get()}"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary

Replaces the ~99-line `CryptoString` wrapper (a `CharSequence`/`Comparable` class with mutable state and several constructors) with a **`@JvmInline value class`** — simpler API, zero runtime overhead, and a step toward KMP-readiness.

```kotlin
@JvmInline
value class CryptoString(private val raw: String) {
    val value: String get() = raw
    companion object { val EMPTY = CryptoString("") }
}
```

> ⚠️ **Breaking change.** See the migration note below and in the README.

## The key safety mechanism

Room 2.6+ natively unwraps value classes to their underlying column type — which, for a `String`-backed `CryptoString`, would **bypass the converter and silently store plaintext**. The fix: the backing property is **`private`**, so Room can't auto-unwrap it and the `@TypeConverter` becomes mandatory — *forgetting it is a compile error, not a silent plaintext leak.* Proven by spike:

| Variant | Backing property | Converter | Result |
|---|---|---|---|
| public `val` | — | none | compiles → fail-silent (plaintext) ⚠️ |
| **private `val`** | — | none | **compile error → fail-loud** ✅ |
| private `val` | — | yes | round-trips, stores **ciphertext** ✅ |

Zero overhead is retained (still inlines to `String`; non-null converter param stays unboxed).

## What changed

- `CryptoString` → value class + `EMPTY`; utilities moved to `CryptoStringExtensions.kt` (`encrypt`, `toCryptoString`, `decryptToCryptoString`, `contentEquals`, `length`, `isEmpty`/`isNotEmpty`/`isBlank`/`isNotBlank`, `compareTo`).
- `CryptoStringTypeConverter` rewritten non-null: `fromCryptoString` / `toCryptoString`.
- `CryptoRoomDatabase`: `getEncryptor`/`getDecryptor` now `internal`; removed the **decorative** base-class `@TypeConverters` (Room never inherited it for subclasses — verified by spike).
- Tests migrated for the value class; **100% coverage retained**, 95% Kover gate green.
- Docs: README `CryptoString` section + migration note, KDoc, and a trimmed ADR (`docs/VALUE_CLASS_REDESIGN.md`).

## Migration

`CharSequence` behaviour, in-place mutation (`value =`/`setValue`), the extra constructors (`CryptoString()`, copy, decryptor), the `+` operator, and `cryptoString == "plainString"` are removed. Use `.value` (e.g. `cryptoString.value == "plainString"`), `String.toCryptoString()`, `entity.copy(secret = CryptoString(…))`, or the new extensions. **Entity fields and `setCryptoHelpers(...)` are unchanged** — the testapp needed no changes.

## Not included

An automated negative-compilation guard for the private-property invariant is **deferred** — `kotlin-compile-testing` (kctfork 0.7.1) bundles Kotlin/KSP 2.1.10 and crashes running Room 2.8.4's processor under Kotlin 2.4. The invariant rests on the KDoc + the spike evidence until kctfork supports Kotlin 2.4 (tracked in the ADR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)