### PR TITLE
Release 2.8.4.2: ship R8 consumer rules

### DIFF
--- a/CryptoRoomDB/build.gradle.kts
+++ b/CryptoRoomDB/build.gradle.kts
@@ -25,6 +25,11 @@ configure<LibraryExtension> {
         minSdk = libs.versions.baseRepoMinSdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        // Ships in the AAR so consuming apps inherit the keeps for CryptoRoomDB's
+        // R8-sensitive surface (TypeConverter, CryptoString, CryptoRoomDatabase).
+        // The library itself stays unminified; these rules are for consumers only.
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     buildTypes {

--- a/CryptoRoomDB/consumer-rules.pro
+++ b/CryptoRoomDB/consumer-rules.pro
@@ -1,0 +1,24 @@
+# === CryptoRoomDB consumer rules ===
+# Shipped in the AAR via consumerProguardFiles; applied automatically in consuming apps.
+#
+# Note: encryption here is TypeConverter-based, NOT reflection-based. Entity field-name
+# obfuscation is governed by the consumer's own Room keeps, so there is no extra
+# obfuscation hazard from the encryption layer — these rules only protect CryptoRoomDB's
+# own R8-sensitive surface.
+
+# Room instantiates the TypeConverter by no-arg constructor in the generated *_Impl
+# (`CryptoStringTypeConverter()`), references it as a KClass in
+# getRequiredTypeConverterClasses(), and calls the @TypeConverter methods directly.
+-keep class com.duck.cryptoroomdb.typeconverter.CryptoStringTypeConverter { <init>(); }
+-keepclassmembers class com.duck.cryptoroomdb.typeconverter.CryptoStringTypeConverter {
+    @androidx.room.TypeConverter <methods>;
+}
+
+# Persisted value type appearing in generated DAO _Impl signatures.
+-keep class com.duck.cryptoroomdb.types.CryptoString { *; }
+
+# Crypto base RoomDatabase reached via the consumer's @Database subclass + its _Impl.
+-keep class com.duck.cryptoroomdb.CryptoRoomDatabase { *; }
+
+# Encryptor/Decryptor deliberately omitted — consumer-implemented and called virtually,
+# no keep needed.

--- a/README.md
+++ b/README.md
@@ -136,6 +136,22 @@ A sample app is included in the `testapp/` module. It demonstrates:
 - Displaying both decrypted and encrypted values
 - Real-time updates using Compose and Flow
 
+## R8 / ProGuard
+
+CryptoRoomDB ships its own consumer rules in the AAR, so the keeps for
+`CryptoStringTypeConverter`, `CryptoString`, and `CryptoRoomDatabase` apply
+automatically — you don't need to add anything for the encryption layer.
+
+You **still** need the standard Room keeps in your app for your own
+`@Entity`/`@Database`/DAO/`_Impl` classes — CryptoRoomDB's rules don't replace them,
+and it can't ship them because it doesn't know your classes. (Modern Room/AGP supply
+most of these via Room's own consumer rules, but your `AutoMigrationSpec` implementors
+and any app-side `@TypeConverter`s remain your responsibility.)
+
+> **Gotcha:** encryption here is **TypeConverter-based, not reflection-based** —
+> entity field-name obfuscation is governed entirely by your Room rules, so there's no
+> extra obfuscation hazard from the encryption layer.
+
 ## License
 
 This project is licensed under the GNU General Public License v3.0 — see the [LICENSE](LICENSE) file for details.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ ksp = "2.3.9"
 room = "2.8.4"
 # Independent library-release revision appended to the Room version (e.g. 2.8.4.1).
 # Bump for library-only releases; reset to 1 when `room` is bumped.
-roomLibRevision = "1"
+roomLibRevision = "2"
 compose-bom = "2026.05.01"
 core-ktx = "1.19.0"
 lifecycle-runtime-ktx = "2.10.0"

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -28,11 +28,19 @@ configure<ApplicationExtension> {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            // Minified so CryptoRoomDB's consumer rules actually get exercised through
+            // R8 (full mode is the AGP default). Run an insert/read round-trip on a
+            // release build to validate the keeps are sufficient.
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
             )
+            // Demo app only — sign release with the debug key so the R8 build is
+            // directly installable/runnable without managing a keystore. Do NOT copy
+            // this into a real publishable app.
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 


### PR DESCRIPTION
## Release 2.8.4.2

First release to ship CryptoRoomDB's own R8/ProGuard consumer rules. Room stays at `2.8.4`; `roomLibRevision` bumped 1 → 2.

### What's in it

- **Consumer rules shipped in the AAR** (`consumerProguardFiles`) — consuming apps automatically inherit keeps for the library's R8-sensitive surface:
  - `CryptoStringTypeConverter` (no-arg ctor + `@TypeConverter` methods — Room instantiates/references it from the generated `*_Impl`)
  - `CryptoString` (value type in generated DAO `_Impl` signatures)
  - `CryptoRoomDatabase` (base `RoomDatabase` reached via the consumer's `@Database`)
- **README "R8 / ProGuard" section**, including the key gotcha: encryption is TypeConverter-based, *not* reflection-based, so entity field-name obfuscation stays governed by the consumer's own Room keeps — no extra hazard from the encryption layer.
- **testapp now minifies + debug-signs its release build**, so the consumer rules are exercised through full-mode R8 on every release build instead of the library drifting back to never-minified.

### Validation

The library had never been run through R8 in its own repo before this. Encrypt/decrypt round-trip **confirmed working on a minified, full-mode-R8 release build** on device.

### Why it mattered

`consumer-rules.pro` was empty *and* unwired, and the demo app had `isMinifyEnabled = false` — so the library shipped with zero R8 coverage. Consuming apps were only covered by accident (broad `-keep class **_Impl { *; }` reachability). These rules make it correct by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)